### PR TITLE
Make IQ work when keyboard is already shown

### DIFF
--- a/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyBoardManager.h
+++ b/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyBoardManager.h
@@ -38,6 +38,9 @@
     
     //To save keyboard animation duration.
     CGFloat animationDuration;
+  
+    // To save keyboard size
+    CGSize kbSize;
 }
 
 //Call it on your AppDelegate to initialize keyboardManager;

--- a/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyBoardManager.m
+++ b/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyBoardManager.m
@@ -171,18 +171,27 @@ static IQKeyBoardManager *kbManager;
     [self setRootViewFrame:topViewBeginRect];
 }
 
-//UIKeyboard Did shown. Adjusting RootViewController's frame according to device orientation.
+//UIKeyboard Did show
 -(void)keyboardWillShow:(NSNotification*)aNotification
 {
+    //Getting keyboard animation duration
+    CGFloat duration = [[aNotification.userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
+    
+    //Getting UIKeyboardSize.
+    kbSize = [[[aNotification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
+    
+    [self adjustFrameWithDuration:duration];
+}
+
+//UIKeyboard Did show. Adjusting RootViewController's frame according to device orientation.
+-(void)adjustFrameWithDuration:(CGFloat)aDuration {
     //Boolean to know keyboard is showing/hiding
     isKeyboardShowing = YES;
     
-    //Getting keyboard animation duration
-    CGFloat aDuration = [[aNotification.userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
     if (aDuration!= 0.0f)
     {
         //Setitng keyboard animation duration
-        animationDuration = [[aNotification.userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
+        animationDuration = aDuration;
     }
     
     //Getting KeyWindow object.
@@ -190,8 +199,6 @@ static IQKeyBoardManager *kbManager;
     //Getting RootViewController's view.
     UIViewController *rootController = [IQKeyBoardManager topMostController];
     
-    //Getting UIKeyboardSize.
-    CGSize kbSize = [[[aNotification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
     //Converting Rectangle according to window bounds.
     CGRect textFieldViewRect = [textFieldView.superview convertRect:textFieldView.frame toView:window];
     //Getting RootViewRect.
@@ -318,14 +325,8 @@ static IQKeyBoardManager *kbManager;
 //Fetching UITextField object from notification.
 -(void)textFieldDidBeginEditing:(NSNotification*)notification
 {
-    //If keyboard is not showing(At the beginning only). We should save rootViewRect.
-    if (isKeyboardShowing == NO)
-    {
-        UIViewController *rootController = [IQKeyBoardManager topMostController];
-        topViewBeginRect = rootController.view.frame;
-   }
-    
     textFieldView = notification.object;
+    [self commonDidBeginEditing];
 }
 
 //Removing fetched object.
@@ -339,6 +340,7 @@ static IQKeyBoardManager *kbManager;
 -(void)textViewDidBeginEditing:(NSNotification*)notification
 {
     textFieldView = notification.object;
+    [self commonDidBeginEditing];
 }
 
 //Removing fetched object.
@@ -347,10 +349,22 @@ static IQKeyBoardManager *kbManager;
     textFieldView = nil;
 }
 
+// Common code to perform on begin editing
+-(void)commonDidBeginEditing {
+    if (isKeyboardShowing)
+    {
+        // keyboard is already showing. adjust frame.
+        [self adjustFrameWithDuration:0];
+    }
+    else
+    {
+        //keyboard is not showing(At the beginning only). We should save rootViewRect.
+        UIViewController *rootController = [IQKeyBoardManager topMostController];
+        topViewBeginRect = rootController.view.frame;
+    }
+}
+
 @end
-
-
-
 
 
 /*Additional Function*/


### PR DESCRIPTION
Make IQKeyboard work when the keyboard is already shown and the UITextField/UITextView becomes first responder (in this case UIKeyboardWillShowNotification is not fired). Also IQ before this change didn't work for me for UITextView (worked only for UITextField). After the change IQ is working well both for UITextField and UITextView.
