### PR TITLE
Added preprocessor macro to disable NSLog statements in library

### DIFF
--- a/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyboardManager.m
+++ b/KeyboardTextFieldDemo/IQKeyBoardManager/IQKeyboardManager.m
@@ -91,6 +91,11 @@
  \---------------------------------------------------------------------------------------------------/
  */
 
+// Set IQKEYBOARDMANAGER_DEBUG=1 in preprocessor macros under build settings to
+// enable debugging.
+#if !IQKEYBOARDMANAGER_DEBUG
+#define NSLog(...)
+#endif
 
 #import "IQKeyboardManager.h"
 

--- a/KeyboardTextFieldDemo/KeyboardTextFieldDemo.xcodeproj/project.pbxproj
+++ b/KeyboardTextFieldDemo/KeyboardTextFieldDemo.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KeyboardTextFieldDemo/KeyboardTextFieldDemo-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = "IQKEYBOARDMANAGER_DEBUG=1";
 				INFOPLIST_FILE = "KeyboardTextFieldDemo/KeyboardTextFieldDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,6 +330,7 @@
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KeyboardTextFieldDemo/KeyboardTextFieldDemo-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = "IQKEYBOARDMANAGER_DEBUG=0";
 				INFOPLIST_FILE = "KeyboardTextFieldDemo/KeyboardTextFieldDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
If the project is built as a release, NSLog statements are #defined to nothing.
