### PR TITLE
Removed layoutSubviews in IQToolbar to prevent keyboard clipping

### DIFF
--- a/KeyboardTextFieldDemo/IQKeyBoardManager/IQToolbar.m
+++ b/KeyboardTextFieldDemo/IQKeyBoardManager/IQToolbar.m
@@ -34,6 +34,7 @@
 -(void)initialize
 {
     [self sizeToFit];
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
      if (IQ_IS_IOS7_OR_GREATER)
     {
@@ -82,15 +83,15 @@
 //}
 
 //To resize IQToolbar on device rotation.
-- (void) layoutSubviews
-{
-    [super layoutSubviews];
-    CGRect origFrame = self.frame;
-    [self sizeToFit];
-    CGRect newFrame = self.frame;
-    newFrame.origin.y += origFrame.size.height - newFrame.size.height;
-    self.frame = newFrame;
-}
+//- (void) layoutSubviews
+//{
+//    [super layoutSubviews];
+//    CGRect origFrame = self.frame;
+//    [self sizeToFit];
+//    CGRect newFrame = self.frame;
+//    newFrame.origin.y += origFrame.size.height - newFrame.size.height;
+//    self.frame = newFrame;
+//}
 
 -(void)setTintColor:(UIColor *)tintColor
 {


### PR DESCRIPTION
Hi, I removed the layoutSubviews in the IQToolbar to correct issue #52. The layout is taken care by the accessory view in the textfield so this method shouldn't be necessary. It also corrected an issue that clipped the keyboard when rotating to landscape and then portrait.
