### PR TITLE
add podspec and support for manual registering responders

### DIFF
--- a/IQKeyBoardManager.podspec
+++ b/IQKeyBoardManager.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license     = "MIT"
   s.authors     = { "Iftekhar Qurashi" => "hack.iftekhar@gmail.com" }
   s.platforms   = :ios, '5.0'
-  s.source      = {:git => "https://github.com/hackiftekhar/IQKeyboardManager.git", :tag => "v3.2.0" }
+  s.source      = {:git => "https://github.com/phamquy/IQKeyboardManager.git", :tag => "nk1.8" }
   s.source_files= 'Classes', 'IQKeyBoardManager/*.{h,m}'
   s.resources   = 'IQKeyBoardManager/IQKeyboardManager.bundle'
   s.requires_arc= true

--- a/IQKeyBoardManager.podspec
+++ b/IQKeyBoardManager.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name        = "IQKeyboardManager"
+  s.version     = "3.2.0"
+  s.summary     = "Keyboard TextField Manager"
+  s.homepage    = "https://github.com/hackiftekhar/IQKeyboardManager"
+  s.screenshots = "https://raw.githubusercontent.com/hackiftekhar/IQKeyboardManager/master/KeyboardTextFieldDemo/Screenshot/IQKeyboardManagerScreenshot.png"
+  s.license     = "MIT"
+  s.authors     = { "Iftekhar Qurashi" => "hack.iftekhar@gmail.com" }
+  s.platforms   = :ios, '5.0'
+  s.source      = {:git => "https://github.com/hackiftekhar/IQKeyboardManager.git", :tag => "v3.2.0" }
+  s.source_files= 'Classes', 'IQKeyBoardManager/*.{h,m}'
+  s.resources   = 'IQKeyBoardManager/IQKeyboardManager.bundle'
+  s.requires_arc= true
+end

--- a/IQKeyBoardManager/IQKeyboardManager.h
+++ b/IQKeyBoardManager/IQKeyboardManager.h
@@ -72,6 +72,19 @@ extern NSInteger const kIQPreviousNextButtonToolbarTag;
 @property(nonatomic, assign) CGFloat keyboardDistanceFromTextField;
 
 
+/*!
+ @property registeredResponders
+ 
+ @abstract Manual registered responders (should be array of UITextView or UITextField)
+ 
+ @discussion 
+ In some view hierarachy, UITextView and UITextField might not in the same superivew, or contained by a UITableView.
+ Manual registered responders provide way to show Previous/Next button for such the case.
+ 
+ Register your responder when your view load and MUST unregister when you done.
+ */
+@property(nonatomic, strong) NSArray* registeredResponders;
+
 
 
 //IQToolbar handling

--- a/IQKeyBoardManager/IQKeyboardManager.h
+++ b/IQKeyBoardManager/IQKeyboardManager.h
@@ -82,6 +82,7 @@ extern NSInteger const kIQPreviousNextButtonToolbarTag;
  Manual registered responders provide way to show Previous/Next button for such the case.
  
  Register your responder when your view load and MUST unregister when you done.
+ Good place to register your responders is viewWillAppear, and to unregister in viewWillDisappear.
  */
 @property(nonatomic, strong) NSArray* registeredResponders;
 

--- a/IQKeyBoardManager/IQKeyboardManager.m
+++ b/IQKeyBoardManager/IQKeyboardManager.m
@@ -850,6 +850,10 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 /*!	Get all UITextField/UITextView siblings of textFieldView. */
 -(NSArray*)responderViews
 {
+    if (_registeredResponders && _registeredResponders.count) {
+        return _registeredResponders;
+    }
+    
     UITableView *tableView = [_textFieldView superTableView];
     
     NSArray *textFields;


### PR DESCRIPTION
1. Add podspec file

2. Add support for manual registering responders:
In some view hierarachy, UITextView and UITextField might not in the same superivew, or contained by a UITableView. Manual registered responders provide way to show Previous/Next button for such the case.