### PR TITLE
Fix crash by checking for `nil` view controllers prior to adding them to the array.

### DIFF
--- a/IQKeyBoardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyBoardManager/Categories/IQUIView+Hierarchy.m
@@ -94,14 +94,20 @@ Class UISearchBarTextFieldClass;        //UISearchBar
     NSMutableArray *controllersHierarchy = [[NSMutableArray alloc] init];
     
     UIViewController *topController = self.window.rootViewController;
-    
-    [controllersHierarchy addObject:topController];
-    
-    while ([topController presentedViewController]) {
-        
-        topController = [topController presentedViewController];
+    if (topController) {
         [controllersHierarchy addObject:topController];
     }
+    
+    do
+    {
+        topController = [topController presentedViewController];
+        
+        if (topController) {
+            [controllersHierarchy addObject:topController];
+        } else {
+            break;
+        }
+    } while (YES);
     
     UIResponder *matchController = [self viewController];
     


### PR DESCRIPTION
I'm seeing a stack trace with the issue below. I believe this PR should fix.

```
exception NSInvalidArgumentException
location IQUIView+Hierarchy.m line 102 in [UIView(IQ_UIView_Hierarchy) topMostController]
time Today, 9:09
message *** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
CoreFoundation	Show CPU registers___exceptionPreprocess
libobjc.A.dylib	_objc_exception_throw
CoreFoundation	_CFStringConvertNSStringEncodingToEncoding
IQUIView+Hierarchy.m line 102 in [UIView(IQ_UIView_Hierarchy) topMostController]
IQKeyboardManager.m line 1025 in [IQKeyboardManager textFieldViewDidBeginEditing:]
```