### PR TITLE
add "IQIgnoreGroup" property for the view wrapped textfield

### DIFF
--- a/IQKeyBoardManager/IQKeyboardManager.m
+++ b/IQKeyBoardManager/IQKeyboardManager.m
@@ -24,6 +24,7 @@
 #import "IQKeyboardManager.h"
 #import "IQUIView+Hierarchy.h"
 #import "IQUIView+IQKeyboardToolbar.h"
+#import "IQUIView+IQIgnoreGroup.h"
 #import "IQUIWindow+Hierarchy.h"
 #import "IQNSArray+Sort.h"
 #import "IQToolbar.h"
@@ -1513,6 +1514,15 @@ void _IQShowLog(NSString *logString);
     if (superConsideredView)
     {
         return [superConsideredView deepResponderViews];
+    }
+    //If the textFieldVie's parentview has setting the property YES, then find the parent's parent ...
+    else if (_textFieldView.superview && _textFieldView.superview.IQIgnoreGroup == YES)
+    {
+        UIView *parentview = _textFieldView.superview;
+        while (parentview.superview && _textFieldView.superview.IQIgnoreGroup == YES) {
+            parentview = parentview.superview;
+        }
+        return [parentview deepResponderViews];
     }
     //Otherwise fetching all the siblings
     else

--- a/IQKeyBoardManager/IQToolbar/IQUIView+IQIgnoreGroup.h
+++ b/IQKeyBoardManager/IQToolbar/IQUIView+IQIgnoreGroup.h
@@ -1,0 +1,28 @@
+//
+//  UIView+IQIgnoreGroup.h
+// https://github.com/hackiftekhar/IQKeyboardManager
+// Copyright (c) 2013-15 Iftekhar Qurashi.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (IQ_UIView_IQIgnoreGroup)
+@property BOOL IQIgnoreGroup;
+@end

--- a/IQKeyBoardManager/IQToolbar/IQUIView+IQIgnoreGroup.m
+++ b/IQKeyBoardManager/IQToolbar/IQUIView+IQIgnoreGroup.m
@@ -1,0 +1,39 @@
+//
+//  UIView+IQIgnoreGroup.m
+// https://github.com/hackiftekhar/IQKeyboardManager
+// Copyright (c) 2013-15 Iftekhar Qurashi.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "IQUIView+IQIgnoreGroup.h"
+#import <objc/runtime.h>
+
+@implementation UIView (IQ_UIView_IQIgnoreGroup)
+static char ignoreGroupKey = 'i';
+- (BOOL)IQIgnoreGroup
+{
+    NSNumber *ignoreGroup = objc_getAssociatedObject(self, @selector(IQIgnoreGroup));
+    return [ignoreGroup boolValue];
+}
+
+- (void)setIQIgnoreGroup:(BOOL)ignoreGroup
+{
+    objc_setAssociatedObject(self, @selector(IQIgnoreGroup), [NSNumber numberWithBool:ignoreGroup], OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+@end


### PR DESCRIPTION
hello, i am from china, my english is not very good, but i am working on it.
this commit is about:
Users can make IQKeyboradManager ignore the view of wrapped textfied on finding siblings.

If users want this,They need:
1. #import "IQUIView+IQIgnoreGroup.h"
2. xxxview.IQIgnoreGroup = YES;

I think, do this can be comfortably for layout. Because somtimes, users only need a wrapper view for layout backgroud and so on. thank you for read. :)