### PR TITLE
fix crash: -[UILabel setInputAccessoryView:]: unrecognized selector sent on iOS8.4

### DIFF
--- a/IQKeyBoardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyBoardManager/Categories/IQUIView+Hierarchy.m
@@ -142,7 +142,11 @@ Class UISearchBarTextFieldClass;        //UISearchBar
 -(BOOL)_IQcanBecomeFirstResponder
 {
     [self _setIsAskingCanBecomeFirstResponder:YES];
-    BOOL _IQcanBecomeFirstResponder = ([self canBecomeFirstResponder] && [self isUserInteractionEnabled] && ![self isHidden] && [self alpha]!=0.0 && ![self isAlertViewTextField]  && ![self isSearchBarTextField]);
+    BOOL _IQcanBecomeFirstResponder = [self canBecomeFirstResponder]
+    && [self isUserInteractionEnabled]
+    && [self respondsToSelector:@selector(setInputAccessoryView:)]
+    && ![self isHidden] && [self alpha]!=0.0
+    && ![self isAlertViewTextField]  && ![self isSearchBarTextField];
     
     if (_IQcanBecomeFirstResponder == YES)
     {

--- a/IQKeyBoardManager/IQKeyboardManager.m
+++ b/IQKeyBoardManager/IQKeyboardManager.m
@@ -1557,15 +1557,16 @@ void _IQShowLog(NSString *logString);
 /**	Get all UITextField/UITextView siblings of textFieldView. */
 -(NSArray*)responderViews
 {
-    UIView *superConsideredView;
+    UIView *superConsideredView = nil;
     
     //If find any consider responderView in it's upper hierarchy then will get deepResponderView.
     for (Class consideredClass in _toolbarPreviousNextConsideredClass)
     {
         superConsideredView = [_textFieldView superviewOfClassType:consideredClass];
         
-        if (superConsideredView != nil)
+        if (superConsideredView != nil) {
             break;
+        }
     }
     
     //If there is a superConsideredView in view's hierarchy, then fetching all it's subview that responds. No sorting for superConsideredView, it's by subView position.    (Enhancement ID: #22)
@@ -1608,12 +1609,12 @@ void _IQShowLog(NSString *logString);
     UIViewController *textFieldViewController = [_textFieldView viewController];
     
     //If found any toolbar disabled classes then return. Will not add any toolbar.
-    for (Class disabledToolbarClass in _disabledToolbarClasses)
-        if ([textFieldViewController isKindOfClass:disabledToolbarClass])
-        {
+    for (Class disabledToolbarClass in _disabledToolbarClasses) {
+        if ([textFieldViewController isKindOfClass:disabledToolbarClass]) {
             [self removeToolbarIfRequired];
             return;
         }
+    }
     
     //	Getting all the sibling textFields.
     NSArray *siblings = [self responderViews];
@@ -1623,8 +1624,9 @@ void _IQShowLog(NSString *logString);
     {
         UITextField *textField = nil;
         
-        if ([siblings count])
+        if ([siblings count] > 0) {
             textField = [siblings objectAtIndex:0]; //Not using firstObject method because iOS5 doesn't not support 'firstObject' method.
+        }
         
         //Either there is no inputAccessoryView or if accessoryView is not appropriate for current situation(There is Previous/Next/Done toolbar).
         if (![textField inputAccessoryView] || ([[textField inputAccessoryView] tag] == kIQPreviousNextButtonToolbarTag))

--- a/IQKeyBoardManager/IQKeyboardReturnKeyHandler.m
+++ b/IQKeyBoardManager/IQKeyboardReturnKeyHandler.m
@@ -59,8 +59,7 @@ NSString *const kIQTextFieldReturnKeyType   =   @"kIQTextFieldReturnKeyType";
 
 - (instancetype)init
 {
-    self = [self initWithViewController:nil];
-    return self;
+    return [self initWithViewController:nil];
 }
 
 -(instancetype)initWithViewController:(UIViewController*)controller

--- a/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
+++ b/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
@@ -248,7 +248,7 @@
 
 -(void)addDoneOnKeyboardWithTarget:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)showPlaceholder
 {
-    NSString *title;
+    NSString *title = nil;
     
     if (showPlaceholder && [self respondsToSelector:@selector(placeholder)])    title = [(UITextField*)self placeholder];
     


### PR DESCRIPTION
fix crash: -[UILabel setInputAccessoryView:]: unrecognized selector sent on iOS8.4