### PR TITLE
Add missing Info.plist for Carthage compatibility

### DIFF
--- a/IQKeyboardManagerSwift/Resources/Info.plist
+++ b/IQKeyboardManagerSwift/Resources/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   Info.plist
+   IQKeyboardManagerSwift
+   Created by mihir mehta on 22/09/15.
+   Copyright (c) 2015 IQKeyboardManager. All rights reserved.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.iftekhar.iqkeyboardmanager.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>
+


### PR DESCRIPTION
Carthage build process needs an Info.plist file to be present and correctly filled.
If the file is missing, compilation ends with an error. If the file is empty, simulator (and the device) is unable to run.

See [#297](https://github.com/hackiftekhar/IQKeyboardManager/pull/297)