### PR TITLE
Pass through touches when resigning on touch outside

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -655,6 +655,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
 
         //Creating gesture for @shouldResignOnTouchOutside. (Enhancement ID: #14)
         _tapGesture = UITapGestureRecognizer(target: self, action: "tapRecognized:")
+        _tapGesture.cancelsTouchesInView = true
         _tapGesture.delegate = self
         _tapGesture.enabled = shouldResignOnTouchOutside
         


### PR DESCRIPTION
This resolves https://github.com/hackiftekhar/IQKeyboardManager/issues/338. For the particular use case, most users would expect that their touch would trigger a selection in a view rather than having to tap a second time.

I'm happy to add an option to enable/disable this like `shouldResignOnTouchOutside` if this is not the desired behaviour for all users.