### PR TITLE
Set cancels touches in view to false/NO

### DIFF
--- a/IQKeyBoardManager/IQKeyboardManager.m
+++ b/IQKeyBoardManager/IQKeyboardManager.m
@@ -241,7 +241,7 @@ void _IQShowLog(NSString *logString);
             
             //Creating gesture for @shouldResignOnTouchOutside. (Enhancement ID: #14)
             _tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapRecognized:)];
-            _tapGesture.cancelsTouchesInView = YES;
+            _tapGesture.cancelsTouchesInView = NO;
             [_tapGesture setDelegate:self];
             _tapGesture.enabled = _shouldResignOnTouchOutside;
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -655,7 +655,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
 
         //Creating gesture for @shouldResignOnTouchOutside. (Enhancement ID: #14)
         _tapGesture = UITapGestureRecognizer(target: self, action: "tapRecognized:")
-        _tapGesture.cancelsTouchesInView = true
+        _tapGesture.cancelsTouchesInView = false
         _tapGesture.delegate = self
         _tapGesture.enabled = shouldResignOnTouchOutside
         


### PR DESCRIPTION
Sorry, I made a mistake with #363, it should be set to false/NO so it doesn't interrupt any touches through to the content underneath. 