### PR TITLE
Conversion to int error with textView.returnKeyType

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
@@ -40,6 +40,11 @@ public class IQKeyboardReturnKeyHandler: NSObject , UITextFieldDelegate, UITextV
     public var delegate: protocol<UITextFieldDelegate, UITextViewDelegate>?
     
     /**
+    It help to choose the lastTextField instance from sibling responderViews. Default is IQAutoToolbarBySubviews.
+    */
+    @available(*, deprecated, message="This property will be removed in future release, from now changing this property have no effect and it will read from [[IQKeyboardManager sharedManager] toolbarManageBehaviour.") public var toolbarManageBehaviour = IQAutoToolbarManageBehaviour.BySubviews
+    
+    /**
     Set the last textfield return key type. Default is UIReturnKeyDefault.
     */
     public var lastTextFieldReturnKeyType : UIReturnKeyType = UIReturnKeyType.Default {
@@ -81,7 +86,7 @@ public class IQKeyboardReturnKeyHandler: NSObject , UITextFieldDelegate, UITextV
             if let textField = view as? UITextField {
                 
                 let returnKeyTypeValue = infoDict[kIQTextFieldReturnKeyType] as! NSNumber
-                textField.returnKeyType = UIReturnKeyType(rawValue: returnKeyTypeValue.integerValue)!
+                textField.returnKeyType = UIReturnKeyType(rawValue: Int(returnKeyTypeValue.unsignedIntegerValue))!
                 
                 textField.delegate = infoDict[kIQTextFieldDelegate] as! UITextFieldDelegate?
             } else if let textView = view as? UITextView {
@@ -89,7 +94,7 @@ public class IQKeyboardReturnKeyHandler: NSObject , UITextFieldDelegate, UITextV
                 textView.returnKeyType = UIReturnKeyType(rawValue: (infoDict[kIQTextFieldReturnKeyType] as! NSNumber).integerValue)!
                 
                 let returnKeyTypeValue = infoDict[kIQTextFieldReturnKeyType] as! NSNumber
-                textView.returnKeyType = UIReturnKeyType(rawValue: returnKeyTypeValue.integerValue)!
+                textView.returnKeyType = UIReturnKeyType(rawValue: Int(returnKeyTypeValue.unsignedIntegerValue))!
                 
                 textView.delegate = infoDict[kIQTextFieldDelegate] as! UITextViewDelegate?
             }
@@ -214,13 +219,13 @@ public class IQKeyboardReturnKeyHandler: NSObject , UITextFieldDelegate, UITextV
             if let textField = view as? UITextField {
                 
                 let returnKeyTypeValue = dict[kIQTextFieldReturnKeyType] as! NSNumber
-                textField.returnKeyType = UIReturnKeyType(rawValue: returnKeyTypeValue.integerValue)!
+                textField.returnKeyType = UIReturnKeyType(rawValue: Int(returnKeyTypeValue.unsignedIntegerValue))!
                 
                 textField.delegate = dict[kIQTextFieldDelegate] as! UITextFieldDelegate?
             } else if let textView = view as? UITextView {
                 
                 let returnKeyTypeValue = dict[kIQTextFieldReturnKeyType] as! NSNumber
-                textView.returnKeyType = UIReturnKeyType(rawValue: returnKeyTypeValue.integerValue)!
+                textView.returnKeyType = UIReturnKeyType(rawValue: Int(returnKeyTypeValue.unsignedIntegerValue))!
                 
                 textView.delegate = dict[kIQTextFieldDelegate] as! UITextViewDelegate?
             }


### PR DESCRIPTION
Fixed `Cannot convert value of type 'UInt' to expected argument type 'Int'` error with textView.returnKeyType