### PR TITLE
Fix crash + remove all pre-iOS 8 #available checks

### DIFF
--- a/IQKeyboardManagerSwift.xcodeproj/project.pbxproj
+++ b/IQKeyboardManagerSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46C6D8971C46EF8600824E4C /* IQUIScrollView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C6D8961C46EF8600824E4C /* IQUIScrollView+Additions.swift */; };
 		7579835F1B886B3D00F8E41F /* IQKeyboardManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7579835E1B886B3D00F8E41F /* IQKeyboardManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7579838C1B886C6700F8E41F /* IQNSArray+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757983781B886C6700F8E41F /* IQNSArray+Sort.swift */; };
 		7579838D1B886C6700F8E41F /* IQUITextFieldView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757983791B886C6700F8E41F /* IQUITextFieldView+Additions.swift */; };
@@ -28,6 +29,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		46C6D8961C46EF8600824E4C /* IQUIScrollView+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUIScrollView+Additions.swift"; sourceTree = "<group>"; };
 		757983591B886B3D00F8E41F /* IQKeyboardManagerSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IQKeyboardManagerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7579835E1B886B3D00F8E41F /* IQKeyboardManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = IQKeyboardManager.h; path = ../IQKeyboardManager/IQKeyboardManager.h; sourceTree = "<group>"; };
 		757983751B886C2700F8E41F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = IQKeyboardManagerSwift/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
@@ -111,6 +113,7 @@
 				7579837A1B886C6700F8E41F /* IQUIView+Hierarchy.swift */,
 				7579837B1B886C6700F8E41F /* IQUIViewController+Additions.swift */,
 				7579837C1B886C6700F8E41F /* IQUIWindow+Hierarchy.swift */,
+				46C6D8961C46EF8600824E4C /* IQUIScrollView+Additions.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -251,6 +254,7 @@
 				7579838D1B886C6700F8E41F /* IQUITextFieldView+Additions.swift in Sources */,
 				7579838E1B886C6700F8E41F /* IQUIView+Hierarchy.swift in Sources */,
 				757983951B886C6700F8E41F /* IQTextView.swift in Sources */,
+				46C6D8971C46EF8600824E4C /* IQUIScrollView+Additions.swift in Sources */,
 				7579838F1B886C6700F8E41F /* IQUIViewController+Additions.swift in Sources */,
 				757983911B886C6700F8E41F /* IQKeyboardManagerConstants.swift in Sources */,
 				757983971B886C6700F8E41F /* IQTitleBarButtonItem.swift in Sources */,

--- a/IQKeyboardManagerSwift.xcodeproj/project.pbxproj
+++ b/IQKeyboardManagerSwift.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = IQKeyboardManager;
 				TargetAttributes = {
 					757983581B886B3D00F8E41F = {
@@ -289,6 +289,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -368,6 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.iftekhar.iqkeyboardmanager.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -387,6 +389,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.iftekhar.iqkeyboardmanager.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/IQKeyboardManagerSwift.xcodeproj/xcshareddata/xcschemes/IQKeyboardManagerSwift.xcscheme
+++ b/IQKeyboardManagerSwift.xcodeproj/xcshareddata/xcschemes/IQKeyboardManagerSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,15 +38,18 @@
             ReferencedContainer = "container:IQKeyboardManagerSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -61,10 +64,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -1820,7 +1820,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                             //Setting toolbar tintColor //  (Enhancement ID: #30)
                             if shouldToolbarUsesTextFieldTintColor {
                                 toolbar.tintColor = _textField.tintColor
-                            } else if let tintColor = _toolbarTintColor {
+                            } else if let tintColor = toolbarTintColor {
                                 toolbar.tintColor = tintColor
                             } else {
                                 toolbar.tintColor = UIColor.blackColor()
@@ -1838,8 +1838,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                             toolbar.barStyle = UIBarStyle.Default
                             
                             if shouldToolbarUsesTextFieldTintColor {
-                                toolbar.tintColor = _textField.tintColor
-                            } else if let tintColor = _toolbarTintColor {
+                                toolbar.tintColor = textField.tintColor
+                            } else if let tintColor = toolbarTintColor {
                                 toolbar.tintColor = tintColor
                             } else {
                                 toolbar.tintColor = UIColor.blackColor()
@@ -1907,7 +1907,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
 
                                 if shouldToolbarUsesTextFieldTintColor {
                                     toolbar.tintColor = _textField.tintColor
-                                } else if let tintColor = _toolbarTintColor {
+                                } else if let tintColor = toolbarTintColor {
                                     toolbar.tintColor = tintColor
                                 } else {
                                     toolbar.tintColor = UIColor.blackColor()
@@ -1925,8 +1925,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                                 toolbar.barStyle = UIBarStyle.Default
 
                                 if shouldToolbarUsesTextFieldTintColor {
-                                    toolbar.tintColor = _textField.tintColor
-                                } else if let tintColor = _toolbarTintColor {
+                                    toolbar.tintColor = textField.tintColor
+                                } else if let tintColor = toolbarTintColor {
                                     toolbar.tintColor = tintColor
                                 } else {
                                     toolbar.tintColor = UIColor.blackColor()

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -669,7 +669,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         _tapGesture.delegate = self
         _tapGesture.enabled = shouldResignOnTouchOutside
         
-        disableInViewControllerClass(UITableViewController)
+        
+        disableDistanceHandlingInViewControllerClass(UITableViewController)
         considerToolbarPreviousNextInViewClass(UITableView)
         considerToolbarPreviousNextInViewClass(UICollectionView)
         
@@ -739,10 +740,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         }
         
         if let unwrappedController = controller {
-            //frame size needs to be adjusted on iOS8 due to orientation structure changes.
-            if #available(iOS 8.0, *) {
-                frame.size = unwrappedController.view.frame.size
-            }
+            //frame size needs to be adjusted on iOS8+ due to orientation structure changes.
+            frame.size = unwrappedController.view.frame.size
             
             //Used UIViewAnimationOptionBeginFromCurrentState to minimize strange animations.
             UIView.animateWithDuration(_animationDuration, delay: 0, options: UIViewAnimationOptions.BeginFromCurrentState.union(_animationCurve), animations: { () -> Void in
@@ -801,13 +800,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         let textFieldViewRect = optionalTextFieldViewRect!
         
         //If it's iOS8 then we should do calculations according to portrait orientations.   //  (Bug ID: #64, #66)
-        let interfaceOrientation : UIInterfaceOrientation
-        
-        if #available(iOS 8.0, *) {
-            interfaceOrientation = UIInterfaceOrientation.Portrait
-        } else {
-            interfaceOrientation = rootController.interfaceOrientation
-        }
+        let interfaceOrientation = UIInterfaceOrientation.Portrait
 
         //  Getting RootViewRect.
         var rootViewRect = rootController.view.frame
@@ -847,15 +840,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
             }
         }
         
-        switch interfaceOrientation {
-        case UIInterfaceOrientation.LandscapeLeft, UIInterfaceOrientation.LandscapeRight:
-            topLayoutGuide = CGRectGetWidth(statusBarFrame)
-            kbSize.width += newKeyboardDistanceFromTextField
-        case UIInterfaceOrientation.Portrait, UIInterfaceOrientation.PortraitUpsideDown:
-            topLayoutGuide = CGRectGetHeight(statusBarFrame)
-            kbSize.height += newKeyboardDistanceFromTextField
-        default:    break
-        }
+        topLayoutGuide = CGRectGetHeight(statusBarFrame)
+        kbSize.height += newKeyboardDistanceFromTextField
 
         var move : CGFloat = 0.0
         //  Move positive = textField is hidden.
@@ -864,30 +850,10 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         //  Checking if there is bottomLayoutGuide attached (Bug ID: #250)
         if layoutGuidePosition == .Bottom {
             //  Calculating move position.
-            switch interfaceOrientation {
-            case UIInterfaceOrientation.LandscapeLeft:
-                move = CGRectGetMaxX(textFieldViewRect)-(CGRectGetWidth(window.frame)-kbSize.width)
-            case UIInterfaceOrientation.LandscapeRight:
-                move = kbSize.width-CGRectGetMinX(textFieldViewRect)
-            case UIInterfaceOrientation.Portrait:
-                move = CGRectGetMaxY(textFieldViewRect)-(CGRectGetHeight(window.frame)-kbSize.height)
-            case UIInterfaceOrientation.PortraitUpsideDown:
-                move = kbSize.height-CGRectGetMinY(textFieldViewRect)
-            default:    break
-            }
+            move = CGRectGetMaxY(textFieldViewRect)-(CGRectGetHeight(window.frame)-kbSize.height)
         } else {
-            //  Calculating move position. Common for both normal and special cases.
-            switch interfaceOrientation {
-            case UIInterfaceOrientation.LandscapeLeft:
-                move = min(CGRectGetMinX(textFieldViewRect)-(topLayoutGuide+5), CGRectGetMaxX(textFieldViewRect)-(CGRectGetWidth(window.frame)-kbSize.width))
-            case UIInterfaceOrientation.LandscapeRight:
-                move = min(CGRectGetWidth(window.frame)-CGRectGetMaxX(textFieldViewRect)-(topLayoutGuide+5), kbSize.width-CGRectGetMinX(textFieldViewRect))
-            case UIInterfaceOrientation.Portrait:
-                move = min(CGRectGetMinY(textFieldViewRect)-(topLayoutGuide+5), CGRectGetMaxY(textFieldViewRect)-(CGRectGetHeight(window.frame)-kbSize.height))
-            case UIInterfaceOrientation.PortraitUpsideDown:
-                move = min(CGRectGetHeight(window.frame)-CGRectGetMaxY(textFieldViewRect)-(topLayoutGuide+5), kbSize.height-CGRectGetMinY(textFieldViewRect))
-            default:    break
-            }
+            //  Calculating move position.
+            move = min(CGRectGetMinY(textFieldViewRect)-(topLayoutGuide+5), CGRectGetMaxY(textFieldViewRect)-(CGRectGetHeight(window.frame)-kbSize.height))
         }
         
         _IQShowLog("Need to move: \(move)")
@@ -986,17 +952,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                                 var expectedFixDistance = shouldOffsetY
                                 
                                 //Calculating expected fix distance which needs to be managed from navigation bar
-                                switch interfaceOrientation {
-                                case UIInterfaceOrientation.LandscapeLeft:
-                                    expectedFixDistance = CGRectGetMinX(currentTextFieldViewRect) - maintainTopLayout
-                                case UIInterfaceOrientation.LandscapeRight:
-                                    expectedFixDistance = (CGRectGetWidth(window.frame)-CGRectGetMaxX(currentTextFieldViewRect)) - maintainTopLayout
-                                case UIInterfaceOrientation.Portrait:
-                                    expectedFixDistance = CGRectGetMinY(currentTextFieldViewRect) - maintainTopLayout
-                                case UIInterfaceOrientation.PortraitUpsideDown:
-                                    expectedFixDistance = (CGRectGetHeight(window.frame)-CGRectGetMaxY(currentTextFieldViewRect)) - maintainTopLayout
-                                default:    break
-                                }
+                                expectedFixDistance = CGRectGetMinY(currentTextFieldViewRect) - maintainTopLayout
                                 
                                 //Now if expectedOffsetY (superScrollView.contentOffset.y + expectedFixDistance) is lower than current shouldOffsetY, which means we're in a position where navigationBar up and hide, then reducing shouldOffsetY with expectedOffsetY (superScrollView.contentOffset.y + expectedFixDistance)
                                 shouldOffsetY = min(shouldOffsetY, scrollView.contentOffset.y + expectedFixDistance)
@@ -1039,17 +995,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                 
                 var bottom : CGFloat = 0.0
                 
-                switch interfaceOrientation {
-                case UIInterfaceOrientation.LandscapeLeft:
-                    bottom = kbSize.width-(CGRectGetWidth(window.frame)-CGRectGetMaxX(lastScrollViewRect))
-                case UIInterfaceOrientation.LandscapeRight:
-                    bottom = kbSize.width-CGRectGetMinX(lastScrollViewRect)
-                case UIInterfaceOrientation.Portrait:
-                    bottom = kbSize.height-(CGRectGetHeight(window.frame)-CGRectGetMaxY(lastScrollViewRect))
-                case UIInterfaceOrientation.PortraitUpsideDown:
-                    bottom = kbSize.height-CGRectGetMinY(lastScrollViewRect)
-                default:    break
-                }
+                bottom = kbSize.height-(CGRectGetHeight(window.frame)-CGRectGetMaxY(lastScrollViewRect))
                 
                 // Update the insets so that the scroll vew doesn't shift incorrectly when the offset is near the bottom of the scroll view.
                 var movedInsets = lastScrollView.contentInset
@@ -1118,13 +1064,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
             if canAdjustTextView == true && _lastScrollView == nil && textFieldView is UITextView == true && _keyboardManagerFlags.isTextFieldViewFrameChanged == false {
                 var textViewHeight = CGRectGetHeight(textFieldView.frame)
                 
-                switch interfaceOrientation {
-                case UIInterfaceOrientation.LandscapeLeft, UIInterfaceOrientation.LandscapeRight:
-                    textViewHeight = min(textViewHeight, (CGRectGetWidth(window.frame)-kbSize.width-(topLayoutGuide+5)))
-                case UIInterfaceOrientation.Portrait, UIInterfaceOrientation.PortraitUpsideDown:
-                    textViewHeight = min(textViewHeight, (CGRectGetHeight(window.frame)-kbSize.height-(topLayoutGuide+5)))
-                default:    break
-                }
+                textViewHeight = min(textViewHeight, (CGRectGetHeight(window.frame)-kbSize.height-(topLayoutGuide+5)))
                 
                 UIView.animateWithDuration(_animationDuration, delay: 0, options: (_animationCurve.union(UIViewAnimationOptions.BeginFromCurrentState)), animations: { () -> Void in
                     
@@ -1154,13 +1094,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                     if preventShowingBottomBlankSpace == true {
                         var minimumY: CGFloat = 0
                         
-                        switch interfaceOrientation {
-                        case UIInterfaceOrientation.LandscapeLeft, UIInterfaceOrientation.LandscapeRight:
-                            minimumY = CGRectGetWidth(window.frame)-rootViewRect.size.height-topLayoutGuide-(kbSize.width-newKeyboardDistanceFromTextField)
-                        case UIInterfaceOrientation.Portrait, UIInterfaceOrientation.PortraitUpsideDown:
-                            minimumY = (CGRectGetHeight(window.frame)-rootViewRect.size.height-topLayoutGuide)/2-(kbSize.height-newKeyboardDistanceFromTextField)
-                        default:    break
-                        }
+                        minimumY = (CGRectGetHeight(window.frame)-rootViewRect.size.height-topLayoutGuide)/2-(kbSize.height-newKeyboardDistanceFromTextField)
                         
                         rootViewRect.origin.y = max(CGRectGetMinY(rootViewRect), minimumY)
                     }
@@ -1198,17 +1132,7 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                     //  From now prevent keyboard manager to slide up the rootView to more than keyboard height. (Bug ID: #93)
                     if preventShowingBottomBlankSpace == true {
                         
-                        switch interfaceOrientation {
-                        case UIInterfaceOrientation.LandscapeLeft:
-                            rootViewRect.origin.x = max(rootViewRect.origin.x, min(0, -kbSize.width+newKeyboardDistanceFromTextField))
-                        case UIInterfaceOrientation.LandscapeRight:
-                            rootViewRect.origin.x = min(rootViewRect.origin.x, +kbSize.width-newKeyboardDistanceFromTextField)
-                        case UIInterfaceOrientation.Portrait:
-                            rootViewRect.origin.y = max(rootViewRect.origin.y, min(0, -kbSize.height+newKeyboardDistanceFromTextField))
-                        case UIInterfaceOrientation.PortraitUpsideDown:
-                            rootViewRect.origin.y = min(rootViewRect.origin.y, +kbSize.height-newKeyboardDistanceFromTextField)
-                        default:    break
-                        }
+                        rootViewRect.origin.y = max(rootViewRect.origin.y, min(0, -kbSize.height+newKeyboardDistanceFromTextField))
                     }
                     
                     _IQShowLog("Moving Upward")
@@ -1217,29 +1141,13 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                 } else {  //  -Negative
                     var disturbDistance : CGFloat = 0
                     
-                    switch interfaceOrientation {
-                    case UIInterfaceOrientation.LandscapeLeft:
-                        disturbDistance = CGRectGetMinX(rootViewRect)-CGRectGetMinX(_topViewBeginRect)
-                    case UIInterfaceOrientation.LandscapeRight:
-                        disturbDistance = CGRectGetMinX(_topViewBeginRect)-CGRectGetMinX(rootViewRect)
-                    case UIInterfaceOrientation.Portrait:
-                        disturbDistance = CGRectGetMinY(rootViewRect)-CGRectGetMinY(_topViewBeginRect)
-                    case UIInterfaceOrientation.PortraitUpsideDown:
-                        disturbDistance = CGRectGetMinY(_topViewBeginRect)-CGRectGetMinY(rootViewRect)
-                    default:    break
-                    }
+                    disturbDistance = CGRectGetMinY(rootViewRect)-CGRectGetMinY(_topViewBeginRect)
                     
                     //  disturbDistance Negative = frame disturbed.
                     //  disturbDistance positive = frame not disturbed.
                     if disturbDistance < 0 {
                         
-                        switch interfaceOrientation {
-                        case UIInterfaceOrientation.LandscapeLeft:       rootViewRect.origin.x -= max(move, disturbDistance)
-                        case UIInterfaceOrientation.LandscapeRight:      rootViewRect.origin.x += max(move, disturbDistance)
-                        case UIInterfaceOrientation.Portrait:            rootViewRect.origin.y -= max(move, disturbDistance)
-                        case UIInterfaceOrientation.PortraitUpsideDown:  rootViewRect.origin.y += max(move, disturbDistance)
-                        default:    break
-                        }
+                        rootViewRect.origin.y -= max(move, disturbDistance)
                         
                         _IQShowLog("Moving Downward")
                         //  Setting adjusted rootViewRect
@@ -1438,10 +1346,8 @@ public class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
             
             if let rootViewController = _rootViewController {
                 
-                //frame size needs to be adjusted on iOS8 due to orientation API changes.
-                if #available(iOS 8.0, *) {
-                    _topViewBeginRect.size = rootViewController.view.frame.size
-                }
+                //frame size needs to be adjusted on iOS8+ due to orientation API changes.
+                _topViewBeginRect.size = rootViewController.view.frame.size
                 
                 //Used UIViewAnimationOptionBeginFromCurrentState to minimize strange animations.
                 UIView.animateWithDuration(_animationDuration, delay: 0, options: UIViewAnimationOptions.BeginFromCurrentState.union(_animationCurve), animations: { () -> Void in

--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -633,25 +633,21 @@ public extension UIView {
             let prev : IQBarButtonItem
             let next : IQBarButtonItem
             
-            if #available(iOS 8.0, *) {
-                
-                // Get the top level "bundle" which may actually be the framework
-                var bundle = NSBundle(forClass: IQKeyboardManager.self)
-                
-                if let resourcePath = bundle.pathForResource("IQKeyboardManager", ofType: "bundle") {
-                    if let resourcesBundle = NSBundle(path: resourcePath) {
-                        bundle = resourcesBundle;
-                    }
+            
+            
+            // Get the top level "bundle" which may actually be the framework
+            var bundle = NSBundle(forClass: IQKeyboardManager.self)
+            
+            if let resourcePath = bundle.pathForResource("IQKeyboardManager", ofType: "bundle") {
+                if let resourcesBundle = NSBundle(path: resourcePath) {
+                    bundle = resourcesBundle;
                 }
-                
-                prev = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowLeft", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
-                
-                next = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowRight", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: nextAction)
-            } else {
-                prev = IQBarButtonItem(image: UIImage(named: "IQKeyboardManager.bundle/IQButtonBarArrowLeft"), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
-                
-                next = IQBarButtonItem(image: UIImage(named: "IQKeyboardManager.bundle/IQButtonBarArrowRight"), style: UIBarButtonItemStyle.Plain, target: target, action: nextAction)
             }
+            
+            prev = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowLeft", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
+            
+            next = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowRight", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: nextAction)
+            
             
             let fixed = IQBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.FixedSpace, target: nil, action: nil)
             fixed.width = 23
@@ -769,25 +765,20 @@ public extension UIView {
             let prev : IQBarButtonItem
             let next : IQBarButtonItem
             
-            if #available(iOS 8.0, *) {
-                
-                // Get the top level "bundle" which may actually be the framework
-                var bundle = NSBundle(forClass: IQKeyboardManager.self)
-                
-                if let resourcePath = bundle.pathForResource("IQKeyboardManager", ofType: "bundle") {
-                    if let resourcesBundle = NSBundle(path: resourcePath) {
-                        bundle = resourcesBundle;
-                    }
+            
+            // Get the top level "bundle" which may actually be the framework
+            var bundle = NSBundle(forClass: IQKeyboardManager.self)
+            
+            if let resourcePath = bundle.pathForResource("IQKeyboardManager", ofType: "bundle") {
+                if let resourcesBundle = NSBundle(path: resourcePath) {
+                    bundle = resourcesBundle;
                 }
-                
-                prev = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowLeft", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
-                
-                next = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowRight", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
-            } else {
-                prev = IQBarButtonItem(image: UIImage(named: "IQKeyboardManager.bundle/IQButtonBarArrowLeft"), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
-                
-                next = IQBarButtonItem(image: UIImage(named: "IQKeyboardManager.bundle/IQButtonBarArrowRight"), style: UIBarButtonItemStyle.Plain, target: target, action: nextAction)
             }
+            
+            prev = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowLeft", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
+            
+            next = IQBarButtonItem(image: UIImage(named: "IQButtonBarArrowRight", inBundle: bundle, compatibleWithTraitCollection: nil), style: UIBarButtonItemStyle.Plain, target: target, action: previousAction)
+          
             
             let fixed = IQBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.FixedSpace, target: nil, action: nil)
             fixed.width = 23

--- a/IQKeyboardManagerSwift/Resources/Info.plist
+++ b/IQKeyboardManagerSwift/Resources/Info.plist
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   Info.plist
-   IQKeyboardManagerSwift
-   Created by mihir mehta on 22/09/15.
-   Copyright (c) 2015 IQKeyboardManager. All rights reserved.
--->
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -15,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.iftekhar.iqkeyboardmanager.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -32,4 +26,3 @@
 	<string></string>
 </dict>
 </plist>
-


### PR DESCRIPTION
Was a little liberal with removing all of the `switch interfaceOrientation`s, after removing the if #available check XCode was telling me that the interfaceOrientation would always be portrait, so having the switches were useless and generating warnings.

Let me know what you think or if I should add those back