### PR TITLE
Fixed Info.plist for Carthage

### DIFF
--- a/Demo/Swift_Demo/Resources/Info.plist
+++ b/Demo/Swift_Demo/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>4.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
Otherwise the resulting framework wouldn't be readable by XCode; "Failed to read file or folder at .../.framework"