### PR TITLE
fix bug: check can become first responder except current first responder

### DIFF
--- a/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
@@ -170,7 +170,7 @@ Class UISearchBarTextFieldClass;        //UISearchBar
     NSMutableArray *tempTextFields = [[NSMutableArray alloc] init];
     
     for (UITextField *textField in siblings)
-        if ([textField _IQcanBecomeFirstResponder])
+        if (![textField isEqual:self] && [textField _IQcanBecomeFirstResponder])
             [tempTextFields addObject:textField];
     
     return tempTextFields;


### PR DESCRIPTION
I set a UITextView instance's delegate to a specific object and implement the **textViewShouldBeginEditing:** method like below:
```objc
- (BOOL)textViewShouldBeginEditing:(UITextView *)textView {
    // do some stuff;
    
    // KVO
    [textView addObserver:self
                      forKeyPath:@"contentSize" 
                            options:(NSKeyValueObservingOptionNew) 
                            context:NULL];

    return YES;
}
```

After receiving **UITextViewTextDidBeginEditingNotification** method **responderSiblings** in the *IQUIView+Hierarchy* category checks current textView/textField's siblings which can become first responder, this will cause the ** textViewShouldBeginEditing:** of the current textView called again, which means the KVO will perform at least twice(Actually it will perform more than twice if you keep open/close keyboard), and this leads to crash if just one KVO removal called.