### PR TITLE
Avoid side effects during removeToolbarIfRequired

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -420,11 +420,6 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     {
         [self addToolbarIfRequired];
     }
-    //Else removing toolbar.
-    else
-    {
-        [self removeToolbarIfRequired];
-    }
 }
 
 -(BOOL)privateIsEnableAutoToolbar
@@ -1807,6 +1802,13 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 /** Remove any toolbar if it is IQToolbar. */
 -(void)removeToolbarIfRequired  //  (Bug ID: #18)
 {
+    
+    if ([self privateIsEnableAutoToolbar] == NO)
+    {
+        // return early if auto toolbar is disabled in order to avoid side effects when calling `inputAccessoryView` on the textField
+        return;
+    }
+    
     //	Getting all the sibling textFields.
     NSArray *siblings = [self responderViews];
     


### PR DESCRIPTION
I've had some cases where calling `[textField inputAccessoryView]` inside `removeToolbarIfRequired` caused some side effects (crashes, e.g. memory management issues) when using a third party library (XLForm). In my opinion it is just not necessary to check for existing toolbars if IQKeyboardManager is disabled (Please correct me if I'm wrong ;)). IQKeyboardManager will just do nothing if it is disabled for a certain controller.