### PR TITLE
Change Info.plist bundle OS type code to framework

### DIFF
--- a/Demo/Objective_C_Demo/Resources/Info.plist
+++ b/Demo/Objective_C_Demo/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>4.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
This pull request changes the Info.plist bundle OS type code of the IQKeyboardManager scheme to framework so that `carthage build` does not fail.