### PR TITLE
Fixing problem with building objective-c module

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.h
+++ b/IQKeyboardManager/IQKeyboardManager.h
@@ -21,6 +21,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import "IQUIView+Hierarchy.h"
+#import "IQUIView+IQKeyboardToolbar.h"
+#import "IQUIWindow+Hierarchy.h"
+#import "IQToolbar.h"
+#import "IQBarButtonItem.h"
+#import "IQUIScrollView+Additions.h"
+#import "IQUITextFieldView+Additions.h"
+#import "IQUIViewController+Additions.h"
+#import "IQPreviousNextView.h"
+#import "IQKeyboardReturnKeyHandler.h"
+#import "IQTextView.h"
+
 #import "IQKeyboardManagerConstants.h"
 
 #import <CoreGraphics/CGBase.h>

--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -22,17 +22,9 @@
 // THE SOFTWARE.
 
 #import "IQKeyboardManager.h"
-#import "IQUIView+Hierarchy.h"
-#import "IQUIView+IQKeyboardToolbar.h"
-#import "IQUIWindow+Hierarchy.h"
 #import "IQNSArray+Sort.h"
-#import "IQToolbar.h"
-#import "IQBarButtonItem.h"
 #import "IQKeyboardManagerConstantsInternal.h"
-#import "IQUIScrollView+Additions.h"
-#import "IQUITextFieldView+Additions.h"
-#import "IQUIViewController+Additions.h"
-#import "IQPreviousNextView.h"
+
 
 #import <UIKit/UINavigationBar.h>
 #import <UIKit/UITapGestureRecognizer.h>


### PR DESCRIPTION
When I have added ```IQKeyboardManager.framework``` to my project using Carthage I have error message saying that Xcode couldn't build module and that umbrella header file not contain other headers. So I have added headers in IQKeyboardManager.h. 

As I firstly facing with such issue, not sure that it is proper way to fix it, but it worked for me. 