### PR TITLE
Remove UIRequiredDeviceCapabilities from Info.plist

### DIFF
--- a/Demo/Swift_Demo/Resources/Info.plist
+++ b/Demo/Swift_Demo/Resources/Info.plist
@@ -28,10 +28,6 @@
 	<string>Launch</string>
 	<key>UIMainStoryboardFile</key>
 	<string>MainSwift</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UIStatusBarHidden</key>
 	<false/>
 	<key>UIStatusBarStyle</key>


### PR DESCRIPTION
Remove the armv7 requirement from the Swift Demo's Info.plist. It would appear
that its presence prevents apps that link against the IQKeyboardManagerSwift
framework cannot be submitted to the store if this flag is present.

iTunesConnect error message: [Transporter Error Output]: ERROR ITMS-90689:
"Invalid Info.plist key. The key 'UIRequiredDeviceCapabilities' in bundle
MyApp.app/Frameworks/IQKeyboardManagerSwift.framework is invalid for frameworks"

Related to #706.