### PR TITLE
Fix known issues and manual management readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ## Known Issues:-
 
-You can find known issues list [here](https://github.com/hackiftekhar/IQKeyboardManager/blob/master/KNOWN ISSUES.md).
+You can find known issues list [here](https://github.com/hackiftekhar/IQKeyboardManager/blob/master/KNOWN%20ISSUES.md).
 
 Manual Management:-
 ---
 
-You can find some manual management tweaks & examples [here](https://github.com/hackiftekhar/IQKeyboardManager/blob/master/MANUAL MANAGEMENT.md).
+You can find some manual management tweaks & examples [here](https://github.com/hackiftekhar/IQKeyboardManager/blob/master/MANUAL%20MANAGEMENT.md).
 
 
 


### PR DESCRIPTION
The link formatting in the readme was causing a couple of the links to be broken. This fixes that.