### PR TITLE
address new warnings in Swift 3.1

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -374,7 +374,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                 //If it refuses to resign then becoming it first responder again for getting notifications callback.
                 textFieldRetain.becomeFirstResponder()
                 
-                showLog("Refuses to resign first responder: \(_textFieldView?._IQDescription())")
+                showLog("Refuses to resign first responder: \(String(describing: _textFieldView?._IQDescription()))")
             }
             
             return isResignFirstResponder
@@ -871,7 +871,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                 
                 //  Setting it's new frame
                 unwrappedController.view.frame = newFrame
-                self.showLog("Set \(controller?._IQDescription()) frame to : \(newFrame)")
+                self.showLog("Set \(String(describing: controller?._IQDescription())) frame to : \(newFrame)")
                 
                 //Animating content if needed (Bug ID: #204)
                 if self.layoutIfNeededOnUpdate == true {

--- a/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
@@ -37,7 +37,7 @@ open class IQKeyboardReturnKeyHandler: NSObject , UITextFieldDelegate, UITextVie
     /**
     Delegate of textField/textView.
     */
-    open weak var delegate: UITextFieldDelegate & UITextViewDelegate?
+    open weak var delegate: (UITextFieldDelegate & UITextViewDelegate)?
     
     /**
     Set the last textfield return key type. Default is UIReturnKeyDefault.

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -25,11 +25,20 @@
 import UIKit
 
 open class IQBarButtonItem: UIBarButtonItem {
-   
-    override open class func initialize() {
 
-        superclass()?.initialize()
-        
+    private static var _appearance: Void = setUpAppearance()
+
+    public override init() {
+        _ = IQBarButtonItem._appearance
+        super.init()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        _ = IQBarButtonItem._appearance
+        super.init(coder: aDecoder)
+    }
+
+    private class func setUpAppearance() {
         //Tint color
         self.appearance().tintColor = nil
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
@@ -30,10 +30,9 @@ private var kIQToolbarTitleInvocationSelector   = "kIQToolbarTitleInvocationSele
 /** @abstract   IQToolbar for IQKeyboardManager.    */
 open class IQToolbar: UIToolbar , UIInputViewAudioFeedback {
 
-    override open class func initialize() {
-        
-        superclass()?.initialize()
-                
+    private static var _appearance: Void = setUpAppearance()
+
+    private class func setUpAppearance() {
         self.appearance().barTintColor = nil
         
         //Background image
@@ -132,6 +131,7 @@ open class IQToolbar: UIToolbar , UIInputViewAudioFeedback {
     }
     
     override init(frame: CGRect) {
+        _ = IQToolbar._appearance
         super.init(frame: frame)
         
         sizeToFit()
@@ -141,6 +141,7 @@ open class IQToolbar: UIToolbar , UIInputViewAudioFeedback {
     }
     
     required public init?(coder aDecoder: NSCoder) {
+        _ = IQToolbar._appearance
         super.init(coder: aDecoder)
 
         sizeToFit()


### PR DESCRIPTION
I'm not really thrilled with the alternative approach to overriding `initialize()`, using a lazy static variable and then reading it in `init` methods. It works though.