### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/KNOWN ISSUES.md
+++ b/KNOWN ISSUES.md
@@ -1,15 +1,15 @@
-##1) Manually enable IQKeyboardManager Swift Version.
+## 1) Manually enable IQKeyboardManager Swift Version.
 
 From Swift 1.2, compiler no longer allows to override `class func load()` method, so you need to manually enable IQKeyboardManager using below line of code in AppDelegate.
 
 ```swift
     IQKeyboardManager.sharedManager().enable = true
 ```
-##2) IQLayoutGuideConstraint with CocoaPods or Carthage.
+## 2) IQLayoutGuideConstraint with CocoaPods or Carthage.
 
 For CoacoaPods or Carthage, IQLayoutGuideConstraints may not be visible in storyboard. For a workaround you should set it programmatically
 
-##3) Keyboard does not appear in iOS Simulator
+## 3) Keyboard does not appear in iOS Simulator
 ([#62](https://github.com/hackiftekhar/IQKeyboardManager/issues/62), [#72](https://github.com/hackiftekhar/IQKeyboardManager/issues/72), [#75](https://github.com/hackiftekhar/IQKeyboardManager/issues/75), [#90](https://github.com/hackiftekhar/IQKeyboardManager/issues/90), [#100](https://github.com/hackiftekhar/IQKeyboardManager/issues/100))
 
 ![Known Issue](https://raw.githubusercontent.com/hackiftekhar/IQKeyboardManager/v3.3.0/Screenshot/IQKeyboardManagerKnownIssue1.png)
@@ -20,7 +20,7 @@ If keyboard does not appear in iOS Simulator and only toolbar is appearing over 
 
 ***Xcode 5 and earlier:-*** Goto ***iOS Simulator->Menu->Hardware->Simulate Hardware Keyboard***, and deselect that.
 
-##4) setEnable = NO doesn't disable automatic UIToolbar
+## 4) setEnable = NO doesn't disable automatic UIToolbar
 ([#117](https://github.com/hackiftekhar/IQKeyboardManager/issues/117), [#136](https://github.com/hackiftekhar/IQKeyboardManager/issues/136), [#147](https://github.com/hackiftekhar/IQKeyboardManager/issues/147))
 
 If you set ***[[IQKeyboardManager sharedManager] setEnable:NO]*** and still automatic toolbar appears on textFields? Probably you haven't heard about ***@property enableAutoToolbar***.
@@ -29,12 +29,12 @@ If you set ***[[IQKeyboardManager sharedManager] setEnable:NO]*** and still auto
 
 ***@property enableAutoToolbar :*** It enable/disable automatic creation of toolbar, please set enableAutoToolbar to NO if you don't want to add automatic toolbar.
 
-##3) Not working when pinning textfield from TopLayoutguide
+## 3) Not working when pinning textfield from TopLayoutguide
 ([#124](https://github.com/hackiftekhar/IQKeyboardManager/issues/124), [#137](https://github.com/hackiftekhar/IQKeyboardManager/issues/137), [#160](https://github.com/hackiftekhar/IQKeyboardManager/issues/160), [#206](https://github.com/hackiftekhar/IQKeyboardManager/issues/206))
 
 Now IQKeyboardManager can work with topLayoutConstraint and bottomLayoutConstraint with a bit of manual management. Please check below ***Manual Management->Working with TopLayoutGuide and BottomLayoutGuide*** section.
 
-##5) Toolbar becomes black while popping from a view controller
+## 5) Toolbar becomes black while popping from a view controller
 ([#374](https://github.com/hackiftekhar/IQKeyboardManager/issues/374))
 
 This issue happens when there is a textField active on a view controller and you navigate to another view controller without resigning currently active textField. This is an iOS issue and happens even if you don't integrate library.

--- a/MANUAL MANAGEMENT.md
+++ b/MANUAL MANAGEMENT.md
@@ -1,4 +1,4 @@
-##Keep UINavigationBar at the top (Don't scroll with keyboard)
+## Keep UINavigationBar at the top (Don't scroll with keyboard)
 ([#21](https://github.com/hackiftekhar/IQKeyboardManager/issues/21), [#24](https://github.com/hackiftekhar/IQKeyboardManager/issues/24))
 
   If you don't want to hide the default UINavigationBar of UINavigationController when keyboardManager slides up the view, then just change the UIView class to UIScrollView from the storyboard  or xib. If you are using Autoresizing then you must set correct contentSize of scrollView or if you are using Autolayout then make sure scrollView is able to get it's contentSize from constraints.
@@ -17,7 +17,7 @@
     }
 ```
 
-##Working with TopLayoutGuide and BottomLayoutGuide
+## Working with TopLayoutGuide and BottomLayoutGuide
 
  Technically IQKeyboardManager moves upwards/downwards of currently presentedViewController's view. So if you're pinning your UITextfield/UITextView with TopLayoutGuide/BottomLayoutGuide then you're saying **Keep x distance from screen top(I don't care about where is self.view)**'. In this case your view is moved upwards but textField remains at same position and keeping x distance from screen top.
 
@@ -29,7 +29,7 @@
 ![image](https://raw.githubusercontent.com/hackiftekhar/IQKeyboardManager/v3.3.0/Screenshot/BottomLayoutGuideIndirectMapping.jpg)
 
 
-##Working with Full Screen UITextView
+## Working with Full Screen UITextView
 
  Often we have a situation where a **full screen UITextView** need to show in full screen mode with keyboard handling. To deal with this kind of situation, here is an easy workaround.
 
@@ -47,7 +47,7 @@
 ![image](https://github.com/hackiftekhar/IQKeyboardManager/raw/master/Screenshot/FullScreenTextViewStoryboard.jpeg)
 
 
-##Working with Chat Screen UITableView
+## Working with Chat Screen UITableView
 
  Often we have another situation where we have to implement our own **Chat Style Screen** with keyboard handling. To deal with this kind of situation, here is an easy workaround.
 
@@ -81,7 +81,7 @@ That's all. You have a working keyboard handling with **ChatViewController**.
 ![image](https://github.com/hackiftekhar/IQKeyboardManager/raw/master/Screenshot/ChatScreenTableView.jpg)
 
 
-##Enable/Disable distance handling between different ViewController's
+## Enable/Disable distance handling between different ViewController's
 ([#117](https://github.com/hackiftekhar/IQKeyboardManager/issues/117), [#139](https://github.com/hackiftekhar/IQKeyboardManager/issues/139),
 [#516](https://github.com/hackiftekhar/IQKeyboardManager/issues/516),
 [#541](https://github.com/hackiftekhar/IQKeyboardManager/issues/541),
@@ -108,7 +108,7 @@ That's all. You have a working keyboard handling with **ChatViewController**.
     }
 ```
 
-##Enable/Disable UIToolbar between different ViewController's
+## Enable/Disable UIToolbar between different ViewController's
 ([#391](https://github.com/hackiftekhar/IQKeyboardManager/issues/391),
 [#530](https://github.com/hackiftekhar/IQKeyboardManager/issues/530))
 
@@ -133,7 +133,7 @@ If you would like to ignore `IQKeyboardManger.enableAutoToolbar` property for so
     }
 ```
 
-##Show Previous/Next arrow buttons for textField which are not direct disblings
+## Show Previous/Next arrow buttons for textField which are not direct disblings
 ([#154](https://github.com/hackiftekhar/IQKeyboardManager/issues/154), [#179](https://github.com/hackiftekhar/IQKeyboardManager/issues/179),
 [#380](https://github.com/hackiftekhar/IQKeyboardManager/issues/380),
 [#406](https://github.com/hackiftekhar/IQKeyboardManager/issues/406),
@@ -167,7 +167,7 @@ If you would like to use your own SpecialView (subclass of UIView) instead of de
     }
 ```
 
-##Hide UIToolbar for specific UITextField/UITextView
+## Hide UIToolbar for specific UITextField/UITextView
 ([#89](https://github.com/hackiftekhar/IQKeyboardManager/issues/89),
 [#533](https://github.com/hackiftekhar/IQKeyboardManager/issues/533))
 
@@ -177,7 +177,7 @@ If you don't want to add automatic toolbar over keyboard for specific textField 
 textField.inputAccessoryView = [[UIView alloc] init];
 ```
 
-##Change UIToolbar Done button text or replace it with some other icon
+## Change UIToolbar Done button text or replace it with some other icon
 ([#538](https://github.com/hackiftekhar/IQKeyboardManager/issues/538),
 [#557](https://github.com/hackiftekhar/IQKeyboardManager/issues/557))
 
@@ -191,7 +191,7 @@ or if you would like to replace this with an image then you should could do like
     [IQKeyboardManager sharedManager].toolbarDoneBarButtonItemImage = [UIImage imageNamed:@"save"];
 ```
 
-##Full customise control over previous/next/done button for specific UITextField/UITextView
+## Full customise control over previous/next/done button for specific UITextField/UITextView
 ([#40](https://github.com/hackiftekhar/IQKeyboardManager/issues/40))
 
 If you need full control over the previous/next/done button then you should use the UIView category methods to add toolbar over your textField. The UIView category methods are defined in `IQUIView+IQKeyboardToolbar.h` file.
@@ -245,7 +245,7 @@ Then add custom toolbar like this.
 
 ```
 
-##Use keyboard toolbar placeholder as action button
+## Use keyboard toolbar placeholder as action button
 If you would like to use keyboard toolbar placeholder text as action buttons to do something special.
 
 ![image](https://github.com/hackiftekhar/IQKeyboardManager/raw/master/Screenshot/ToolbarButtonAction.jpg)
@@ -270,7 +270,7 @@ This is now very easy with just 2 lines of code like this:-
 
 ```
 
-##Get notified when tapping on previous/next/done button for specific UITextField/UITextView
+## Get notified when tapping on previous/next/done button for specific UITextField/UITextView
 ([#426](https://github.com/hackiftekhar/IQKeyboardManager/issues/426),
 [#475](https://github.com/hackiftekhar/IQKeyboardManager/issues/475),
 [#492](https://github.com/hackiftekhar/IQKeyboardManager/issues/492))
@@ -314,7 +314,7 @@ Then register custom selector.
 }
 ```
 
-##Hide Previous/Next arrow of UIToolbar
+## Hide Previous/Next arrow of UIToolbar
 ([#546](https://github.com/hackiftekhar/IQKeyboardManager/issues/546),
 [#548](https://github.com/hackiftekhar/IQKeyboardManager/issues/548),
 [#579](https://github.com/hackiftekhar/IQKeyboardManager/issues/579))
@@ -329,7 +329,7 @@ If you don't want to show Previous/Next arrow with toolbar and only want to show
 }
 ```
 
-##Keyboard Return Key Handling
+## Keyboard Return Key Handling
 ([#38](https://github.com/hackiftekhar/IQKeyboardManager/issues/38), [#63](https://github.com/hackiftekhar/IQKeyboardManager/issues/63))
 
 If you would like to use keyboard **Return Key** as **Next/Done** button, then you can use **IQKeyboardReturnKeyHandler**.

--- a/PROPERTIES & FUNCTIONS.md
+++ b/PROPERTIES & FUNCTIONS.md
@@ -1,7 +1,7 @@
-##Properties and functions usage:-
+## Properties and functions usage:-
 
 
-####UIKeyboard handling
+#### UIKeyboard handling
 
 ***+(instancetype)sharedManager :***
 Returns the default singleton instance.
@@ -15,7 +15,7 @@ Set Distance between keyboard & textField. Can't be less than zero. Default is 1
 ***@property BOOL preventShowingBottomBlankSpace :***
 Prevent to show bottom blanck area when keyboard slide up the view. Default is YES. ([#93](https://github.com/hackiftekhar/IQKeyboardManager/issues/93)).
 
-####IQToolbar handling
+#### IQToolbar handling
 
 ***@property BOOL enableAutoToolbar :***
 Enable autoToolbar behaviour. If It is set to NO. You have to manually create UIToolbar for keyboard. Default is YES.
@@ -33,7 +33,7 @@ If YES, then it add the textField's placeholder text on IQToolbar. Default is YE
 placeholder Font. Default is nil. ([#27](https://github.com/hackiftekhar/IQKeyboardManager/issues/27))
 
 
-####UITextView handling
+#### UITextView handling
 
 ***@property BOOL canAdjustTextView :***
 Giving permission to modify TextView's frame. Adjust textView's frame when it is too big in height. Default is NO. ([#30](https://github.com/hackiftekhar/IQKeyboardManager/issues/30))
@@ -42,7 +42,7 @@ Giving permission to modify TextView's frame. Adjust textView's frame when it is
 Adjust textView's contentInset to fix fix for iOS 7.0.x -([#Stackoverflow](http://stackoverflow.com/questions/18966675/uitextview-in-ios7-clips-the-last-line-of-text-string)). Default is YES.
 
 
-####UIKeyboard Appearance overriding
+#### UIKeyboard Appearance overriding
 
 ***@property BOOL overrideKeyboardAppearance :***
 Override the keyboardAppearance for all textField/textView. Default is NO.
@@ -51,7 +51,7 @@ Override the keyboardAppearance for all textField/textView. Default is NO.
 If overrideKeyboardAppearance is YES, then all the textField keyboardAppearance is set using this property.
 
 
-####UITextField/UITextView Resign handling
+#### UITextField/UITextView Resign handling
 
 ***@property BOOL shouldResignOnTouchOutside :***
 Resign textField if touched outside of UITextField/UITextView. ([#14](https://github.com/hackiftekhar/IQKeyboardManager/issues/14))
@@ -59,13 +59,13 @@ Resign textField if touched outside of UITextField/UITextView. ([#14](https://gi
 ***-(void)resignFirstResponder :***
 Resigns currently first responder field.
 
-####UISound handling
+#### UISound handling
 
 ***@property BOOL shouldPlayInputClicks :***
 If YES, then it plays inputClick sound on next/previous/done click. Default is NO.
 
 
-####UIAnimation handling
+#### UIAnimation handling
 
 ***@property BOOL shouldAdoptDefaultKeyboardAnimation :***
 If YES, then uses keyboard default animation curve style to move view, otherwise uses UIViewAnimationOptionCurveEaseOut animation style. Default is YES.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ You can find some manual management tweaks & examples [here](https://github.com/
 [![IQKeyboardManager CFD](https://raw.githubusercontent.com/hackiftekhar/IQKeyboardManager/v3.3.0/Screenshot/IQKeyboardManagerCFD.jpg)](https://raw.githubusercontent.com/hackiftekhar/IQKeyboardManager/v3.3.0/Screenshot/IQKeyboardManagerCFD.jpg)
 
 
-##Properties and functions usage:-
+## Properties and functions usage:-
 
 You can find some documentation about properties, methods and their uses [here](https://github.com/hackiftekhar/IQKeyboardManager/blob/master/PROPERTIES%20%26%20FUNCTIONS.md).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
