### PR TITLE
829 Add ability to destroy singleton

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -76,14 +76,8 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         }
     }
     
-    open var canBecomeActive = true
-    
     fileprivate func privateIsEnabled()-> Bool {
-        
-        if !canBecomeActive {
-            return false
-        }
-        
+
         var isEnabled = enable
         
         if let textFieldViewController = _textFieldView?.viewController() {
@@ -155,18 +149,27 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
     */
     open var preventShowingBottomBlankSpace = true
     
+    
+    open class func destroy() {
+        IQKeyboardManager.IQKeyboardManagerStatic.kbManager = nil
+    }
+    
+    fileprivate struct IQKeyboardManagerStatic {
+        //Singleton instance. Initializing keyboard manger.
+        static var kbManager:IQKeyboardManager?
+    }
+    
     /**
     Returns the default singleton instance.
     */
     open class func sharedManager() -> IQKeyboardManager {
         
-        struct Static {
-            //Singleton instance. Initializing keyboard manger.
-            static let kbManager = IQKeyboardManager()
+        if IQKeyboardManagerStatic.kbManager == nil {
+            IQKeyboardManagerStatic.kbManager = IQKeyboardManager()
         }
         
         /** @return Returns the default singleton instance. */
-        return Static.kbManager
+        return IQKeyboardManagerStatic.kbManager!
     }
     
     ///-------------------------

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -76,7 +76,13 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         }
     }
     
+    open var canBecomeActive = true
+    
     fileprivate func privateIsEnabled()-> Bool {
+        
+        if !canBecomeActive {
+            return false
+        }
         
         var isEnabled = enable
         

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -166,7 +166,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
     */
     open class func sharedManager() -> IQKeyboardManager {
         
-        // Initializing keyboard manger singleton, if needed.
+        // Initialize keyboard manager singleton, if needed.
         if IQKeyboardManagerStatic.kbManager == nil {
             IQKeyboardManagerStatic.kbManager = IQKeyboardManager()
         }

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -149,13 +149,15 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
     */
     open var preventShowingBottomBlankSpace = true
     
-    
+    /**
+     Destroy the singleton instance. This will disable IQKeyboardManager and remove notification observers.
+     */
     open class func destroy() {
         IQKeyboardManager.IQKeyboardManagerStatic.kbManager = nil
     }
     
     fileprivate struct IQKeyboardManagerStatic {
-        //Singleton instance. Initializing keyboard manger.
+        //Singleton instance.
         static var kbManager:IQKeyboardManager?
     }
     
@@ -164,6 +166,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
     */
     open class func sharedManager() -> IQKeyboardManager {
         
+        // Initializing keyboard manger singleton, if needed.
         if IQKeyboardManagerStatic.kbManager == nil {
             IQKeyboardManagerStatic.kbManager = IQKeyboardManager()
         }
@@ -813,20 +816,11 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         }
     }
     
-    /** Override +load method to enable KeyboardManager when class loader load IQKeyboardManager. Enabling when app starts (No need to write any code) */
-    /** It doesn't work from Swift 1.2 */
-//    override public class func load() {
-//        super.load()
-//        
-//        //Enabling IQKeyboardManager.
-//        IQKeyboardManager.sharedManager().enable = true
-//    }
-    
     deinit {
-        //  Disable the keyboard manager.
+        // Disable the keyboard manager.
         enable = false
 
-        //Removing notification observers on dealloc.
+        // Removing notification observers on dealloc.
         NotificationCenter.default.removeObserver(self)
     }
     


### PR DESCRIPTION
Per #829 setting `IQKeyboardManager.sharedManager().enable = false` doesn't disable the keyboard manager. In addition adding classes to `disabledDistanceHandlingClasses` doesn't apply if the UITextField or UITextView isn't part of a UIViewController. I have added `IQKeyboardManager.destroy()` to give user the ability to destroy the singleton which completely removes all observers. 

The below example would allow the use of the manager for 1 view controller.

```swift
    override func viewWillAppear(_ animated: Bool) {
        IQKeyboardManager.sharedManager().enable = true
    }
    
    override func viewWillDisappear(_ animated: Bool) {
        IQKeyboardManager.destroy()
    }
```