### PR TITLE
[IQTextView] correct aligment with placeholder and the cursor

### DIFF
--- a/IQKeyboardManager/IQTextView/IQTextView.m
+++ b/IQKeyboardManager/IQTextView/IQTextView.m
@@ -99,7 +99,7 @@
     [super layoutSubviews];
 
     [placeHolderLabel sizeToFit];
-    placeHolderLabel.frame = CGRectMake(8, 8, CGRectGetWidth(self.frame)-16, CGRectGetHeight(placeHolderLabel.frame));
+    placeHolderLabel.frame = CGRectMake(4, 8, CGRectGetWidth(self.frame)-16, CGRectGetHeight(placeHolderLabel.frame));
 }
 
 -(void)setPlaceholder:(NSString *)placeholder

--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -84,7 +84,7 @@ open class IQTextView : UITextView {
         
         if let unwrappedPlaceholderLabel = placeholderLabel {
             unwrappedPlaceholderLabel.sizeToFit()
-            unwrappedPlaceholderLabel.frame = CGRect(x: 8, y: 8, width: self.frame.width-16, height: unwrappedPlaceholderLabel.frame.height)
+            unwrappedPlaceholderLabel.frame = CGRect(x: 4, y: 8, width: self.frame.width-16, height: unwrappedPlaceholderLabel.frame.height)
         }
     }
 


### PR DESCRIPTION
The placeholder is alignment with the cursor.

This is before:

![simulator screen shot 24 05 2017 16 04 45](https://cloud.githubusercontent.com/assets/5769029/26427975/715022b0-409c-11e7-97f3-e42d4e1cf154.png)

This is after:

![simulator screen shot 24 05 2017 16 04 18](https://cloud.githubusercontent.com/assets/5769029/26427977/79a0f908-409c-11e7-97f2-744965c3d9a6.png)
