### PR TITLE
[IQTextView] correct multiline placeholder

### DIFF
--- a/IQKeyboardManager/IQTextView/IQTextView.m
+++ b/IQKeyboardManager/IQTextView/IQTextView.m
@@ -98,8 +98,8 @@
 {
     [super layoutSubviews];
 
-    [placeHolderLabel sizeToFit];
     placeHolderLabel.frame = CGRectMake(4, 8, CGRectGetWidth(self.frame)-16, CGRectGetHeight(placeHolderLabel.frame));
+    [placeHolderLabel sizeToFit];
 }
 
 -(void)setPlaceholder:(NSString *)placeholder

--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -83,8 +83,8 @@ open class IQTextView : UITextView {
         super.layoutSubviews()
         
         if let unwrappedPlaceholderLabel = placeholderLabel {
-            unwrappedPlaceholderLabel.sizeToFit()
             unwrappedPlaceholderLabel.frame = CGRect(x: 4, y: 8, width: self.frame.width-16, height: unwrappedPlaceholderLabel.frame.height)
+            unwrappedPlaceholderLabel.sizeToFit()
         }
     }
 


### PR DESCRIPTION
`sizeToFit` is called after setting the placeholder frame to make it multiline.

This is before:

![captura de pantalla 2017-05-31 a la s 09 44 35](https://cloud.githubusercontent.com/assets/5769029/26640837/141644e0-45e6-11e7-85ea-83d0625ff47c.png)

This is after:

![captura de pantalla 2017-05-31 a la s 09 45 21](https://cloud.githubusercontent.com/assets/5769029/26640845/182b5c5a-45e6-11e7-8148-ae3f954922fe.png)

