### PR TITLE
Use textcontainerInset and lineFragmentPadding for placeholderLabel position in IQTextView

### DIFF
--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -85,7 +85,15 @@ open class IQTextView : UITextView {
         
         if let unwrappedPlaceholderLabel = placeholderLabel {
             unwrappedPlaceholderLabel.sizeToFit()
-            unwrappedPlaceholderLabel.frame = CGRect(x: 4, y: 8, width: self.frame.width-16, height: unwrappedPlaceholderLabel.frame.height)
+            let offsetXLeft = textContainerInset.left + textContainer.lineFragmentPadding
+            let offsetXRight = textContainerInset.right
+            let offsetY = textContainerInset.top
+            unwrappedPlaceholderLabel.frame = CGRect(
+                x: offsetXLeft,
+                y: offsetY,
+                width: self.frame.width - offsetXLeft - offsetXRight,
+                height: unwrappedPlaceholderLabel.frame.height
+            )
         }
     }
 


### PR DESCRIPTION
IQTextView's uses a constant value to position the placeholderLabel, setting the textContainer's insets is being ignored. This PR  fixes that.