### PR TITLE
[iOS 11] Fix the bug that app crashes when siblings is empty

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -1947,7 +1947,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
         showLog("****** \(#function) started ******")
 
         //	Getting all the sibling textFields.
-        if let siblings = responderViews() {
+        if let siblings = responderViews(), !siblings.isEmpty {
             
             showLog("Found \(siblings.count) responder sibling(s)")
             


### PR DESCRIPTION
To avoid app crash, I added the logic to check if siblings is not empty. 
On iOS 11, siblings in `IQKeyboardManager` is empty in some cases as shown in the screenshots below.

<img width="640" alt="siblings_empty" src="https://user-images.githubusercontent.com/2959791/30631145-3b61cdb8-9e1e-11e7-9fb7-87fd72171d61.png">
