### PR TITLE
Swift4

### DIFF
--- a/IQKeyboardManagerSwift/Categories/IQUIView+Hierarchy.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUIView+Hierarchy.swift
@@ -55,7 +55,7 @@ public extension UIView {
     /**
     Returns the topMost UIViewController object in hierarchy.
     */
-    public func topMostController()->UIViewController? {
+    @objc public func topMostController()->UIViewController? {
         
         var controllersHierarchy = [UIViewController]()
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -2070,7 +2070,7 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                         
                         //In case of UITableView (Special), the next/previous buttons has to be refreshed everytime.    (Bug ID: #56)
                         //	If firstTextField, then previous should not be enabled.
-                        if siblings[0] == textField {
+                        if siblings.count > 0 && siblings[0] == textField {
                             if (siblings.count == 1) {
                                 textField.setEnablePrevious(false, isNextEnabled: false)
                             } else {


### PR DESCRIPTION
This includes the `@objc` header added by #970. This small change prevents the app from crashing when opening a keyboard for the new iOS 11 navigation search bar. See #981 for more info.