### PR TITLE
Update LICENSE formatting, fix README typo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,16 +1,13 @@
-IQKeyboardManager license
-=========================
+MIT License
 
-The MIT License (MIT)
+Copyright (c) 2013-2017 Iftekhar Qurashi
 
-Copyright (c) 2013-16 Iftekhar Qurashi
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Installation
 it simply add the following line to your Podfile: ([#9](https://github.com/hackiftekhar/IQKeyboardManager/issues/9))
 
 ```ruby
-`pod 'IQKeyboardManager'` #iOS8 and later
+pod 'IQKeyboardManager' #iOS8 and later
 
-`pod 'IQKeyboardManager', '3.3.7'` #iOS7
+pod 'IQKeyboardManager', '3.3.7' #iOS7
 ```
 
 ***IQKeyboardManager (Swift):*** IQKeyboardManagerSwift is available through [CocoaPods](http://cocoapods.org), to install


### PR DESCRIPTION
Reformatted LICENSE.md slightly, so GitHub will pick up license type (MIT) automatically and display it on related badges. Right now it shows `license: Other`.

Also removed unneeded apostrophes in code block (introduced in my previous PR, sorry for that).