### PR TITLE
fix umbreall warning when use objc framework by carthage

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.h
+++ b/IQKeyboardManager/IQKeyboardManager.h
@@ -22,6 +22,18 @@
 // THE SOFTWARE.
 
 #import "IQKeyboardManagerConstants.h"
+#import "IQUIView+IQKeyboardToolbar.h"
+#import "IQPreviousNextView.h"
+#import "IQUIViewController+Additions.h"
+#import "IQKeyboardReturnKeyHandler.h"
+#import "IQUIWindow+Hierarchy.h"
+#import "IQTextView.h"
+#import "IQToolbar.h"
+#import "IQUIScrollView+Additions.h"
+#import "IQUITextFieldView+Additions.h"
+#import "IQBarButtonItem.h"
+#import "IQTitleBarButtonItem.h"
+#import "IQUIView+Hierarchy.h"
 
 #import <CoreGraphics/CGBase.h>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26478957/33541418-069e6ed4-d90a-11e7-95d7-392f877911a9.png)
