### PR TITLE
If you don't want to adjust the frame in some cases.

### DIFF
--- a/IQKeyboardManagerSwift/Categories/IQUIViewController+Additions.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUIViewController+Additions.swift
@@ -45,4 +45,17 @@ public extension UIViewController {
             objc_setAssociatedObject(self, &kIQLayoutGuideConstraint, newValue,objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
+    
+    /**
+     If you don't want to adjust the frame in the case that the textField already positioned above the keyboard, set shouldRestoreScrollViewContentOffset to true inside the viewController
+     */
+    public var shouldMoveWithNegativePosition: Bool? {
+        get {
+            return objc_getAssociatedObject(self, &kShouldMoveWithNegativePosition) as? Bool ?? false
+        }
+        
+        set(newValue) {
+            objc_setAssociatedObject(self, &kShouldMoveWithNegativePosition, newValue,objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
 }

--- a/IQKeyboardManagerSwift/Categories/IQUIViewController+Additions.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUIViewController+Additions.swift
@@ -25,7 +25,7 @@ import UIKit
 
 
 private var kIQLayoutGuideConstraint = "kIQLayoutGuideConstraint"
-private var kShouldMoveWithNegativePosition = "kShouldMoveWithNegativePosition" 
+private var kShouldntMoveWithNegativePosition = "kShouldntMoveWithNegativePosition"
 
 
 public extension UIViewController {
@@ -50,13 +50,13 @@ public extension UIViewController {
     /**
      If you don't want to adjust the frame in the case that the textField already positioned above the keyboard, set shouldRestoreScrollViewContentOffset to true inside the viewController
      */
-    public var shouldMoveWithNegativePosition: Bool? {
+    public var shouldntMoveWithNegativePosition: Bool? {
         get {
-            return objc_getAssociatedObject(self, &kShouldMoveWithNegativePosition) as? Bool ?? false
+            return objc_getAssociatedObject(self, &kShouldntMoveWithNegativePosition) as? Bool ?? false
         }
         
         set(newValue) {
-            objc_setAssociatedObject(self, &kShouldMoveWithNegativePosition, newValue,objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &kShouldntMoveWithNegativePosition, newValue,objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 }

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -1080,6 +1080,11 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
             move = min(textFieldViewRect.minY-(topLayoutGuide+5), textFieldViewRect.maxY-(window.frame.height-kbSize.height))
         }
         
+        // Don't adjust the frame if textField is already placed above the keyboard and shouldMoveWithNegativePosition is true
+        if (move < 0 && (_textFieldView?.viewController()?.shouldMoveWithNegativePosition)!) {
+            return
+        }
+        
         showLog("Need to move: \(move)")
 
         var superScrollView : UIScrollView? = nil

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -1080,8 +1080,8 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
             move = min(textFieldViewRect.minY-(topLayoutGuide+5), textFieldViewRect.maxY-(window.frame.height-kbSize.height))
         }
         
-        // Don't adjust the frame if textField is already placed above the keyboard and shouldMoveWithNegativePosition is true
-        if (move < 0 && (_textFieldView?.viewController()?.shouldMoveWithNegativePosition)!) {
+        // Don't adjust the frame if textField is already placed above the keyboard and shouldntMoveWithNegativePosition is true
+        if (move < 0 && (_textFieldView?.viewController()?.shouldntMoveWithNegativePosition)!) {
             return
         }
         


### PR DESCRIPTION
In the case that you want to adjust the frame in the case that textField will position under the keyboard, 
and don't want to adjust the frame in the case that the textField already positioned above the keyboard.
Set shouldRestoreScrollViewContentOffset to true inside the viewController will do that.