### PR TITLE
IQBarButtonItem Invocation retain cycle problem - Swift Version

### DIFF
--- a/IQKeyboardManager.xcodeproj/project.pbxproj
+++ b/IQKeyboardManager.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		4CD5973E1D1C5EDD00AB28D3 /* IQUIView+IQKeyboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD5972A1D1C5EDD00AB28D3 /* IQUIView+IQKeyboardToolbar.swift */; settings = {ATTRIBUTES = (Private, ); }; };
 		4CD5973F1D1C5EDD00AB28D3 /* IQKeyboardManager.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4CD5972C1D1C5EDD00AB28D3 /* IQKeyboardManager.bundle */; };
 		4CD597421D1C60B000AB28D3 /* IQKeyboardManagerSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD597411D1C60B000AB28D3 /* IQKeyboardManagerSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		63EECD42205FD69A006B42C2 /* IQInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECD41205FD69A006B42C2 /* IQInvocation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,6 +119,7 @@
 		4CD5972C1D1C5EDD00AB28D3 /* IQKeyboardManager.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = IQKeyboardManager.bundle; sourceTree = "<group>"; };
 		4CD597401D1C602500AB28D3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Demo/Swift_Demo/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
 		4CD597411D1C60B000AB28D3 /* IQKeyboardManagerSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardManagerSwift.h; sourceTree = "<group>"; };
+		63EECD41205FD69A006B42C2 /* IQInvocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQInvocation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -315,6 +317,7 @@
 				4CD597281D1C5EDD00AB28D3 /* IQTitleBarButtonItem.swift */,
 				4CD597291D1C5EDD00AB28D3 /* IQToolbar.swift */,
 				4CD5972A1D1C5EDD00AB28D3 /* IQUIView+IQKeyboardToolbar.swift */,
+				63EECD41205FD69A006B42C2 /* IQInvocation.swift */,
 			);
 			path = IQToolbar;
 			sourceTree = "<group>";
@@ -479,6 +482,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CD597301D1C5EDD00AB28D3 /* IQUIView+Hierarchy.swift in Sources */,
+				63EECD42205FD69A006B42C2 /* IQInvocation.swift in Sources */,
 				4CD597331D1C5EDD00AB28D3 /* IQKeyboardManagerConstants.swift in Sources */,
 				4CD597361D1C5EDD00AB28D3 /* IQKeyboardManager.swift in Sources */,
 				4CD597381D1C5EDD00AB28D3 /* IQKeyboardReturnKeyHandler.swift in Sources */,

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -596,11 +596,8 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                     }
                 }
 
-                if isAcceptAsFirstResponder,
-                    let target = invocation?.target,
-                    let action = invocation?.action {
-                    
-                    UIApplication.shared.sendAction(action, to: target, from: textFieldRetain, for: UIEvent())
+                if isAcceptAsFirstResponder {
+                    invocation?.invoke(from: textFieldRetain)
                 }
             }
         }
@@ -628,11 +625,8 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                     }
                 }
 
-                if isAcceptAsFirstResponder,
-                    let target = invocation?.target,
-                    let action = invocation?.action {
-                    
-                    UIApplication.shared.sendAction(action, to: target, from: textFieldRetain, for: UIEvent())
+                if isAcceptAsFirstResponder {
+                    invocation?.invoke(from: textFieldRetain)
                 }
             }
         }
@@ -659,11 +653,8 @@ open class IQKeyboardManager: NSObject, UIGestureRecognizerDelegate {
                 }
             }
 
-            if isResignedFirstResponder,
-                let target = invocation?.target,
-                let action = invocation?.action {
-                
-                UIApplication.shared.sendAction(action, to: target, from: textFieldRetain, for: UIEvent())
+            if isResignedFirstResponder {
+                invocation?.invoke(from: textFieldRetain)
             }
         }
     }

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -109,8 +109,11 @@ open class IQBarButtonItem: UIBarButtonItem {
      @param action Target Selector.
      */
     open func setTarget(_ target: AnyObject?, action: Selector?) {
-        guard let target = target, let action = action else { return }
-        invocation = IQInvocation(target, action)
+        if let target = target, let action = action {
+            invocation = IQInvocation(target, action)
+        } else {
+            invocation = nil
+        }
     }
     
     /**
@@ -120,5 +123,7 @@ open class IQBarButtonItem: UIBarButtonItem {
     
     deinit {
         target = nil
+        invocation?.target = nil
+        invocation = nil
     }
 }

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -109,18 +109,16 @@ open class IQBarButtonItem: UIBarButtonItem {
      @param action Target Selector.
      */
     open func setTarget(_ target: AnyObject?, action: Selector?) {
+        guard let target = target, let action = action else { return }
         invocation = IQInvocation(target, action)
     }
     
     /**
      Customized Invocation to be called when button is pressed. invocation is internally created using setTarget:action: method.
      */
-    open weak var invocation : IQInvocation?
+    open var invocation : IQInvocation?
     
     deinit {
-
         target = nil
-        invocation?.target = nil
-        invocation = nil
     }
 }

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -109,13 +109,13 @@ open class IQBarButtonItem: UIBarButtonItem {
      @param action Target Selector.
      */
     open func setTarget(_ target: AnyObject?, action: Selector?) {
-        invocation = (target, action)
+        invocation = IQInvocation(target, action)
     }
     
     /**
      Customized Invocation to be called when button is pressed. invocation is internally created using setTarget:action: method.
      */
-    open var invocation : (target: AnyObject?, action: Selector?)?
+    open weak var invocation : IQInvocation?
     
     deinit {
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
@@ -1,10 +1,26 @@
 //
-//  Invocation.swift
-//  IQKeyboardManagerSwift
+//  IQKeyboardManager.swift
+// https://github.com/hackiftekhar/IQKeyboardManager
+// Copyright (c) 2013-16 Iftekhar Qurashi.
 //
-//  Created by Metin Güler on 19.03.2018.
-//  Copyright © 2018 IQKeyboardManager. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 
 import Foundation
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
@@ -9,11 +9,17 @@
 import Foundation
 
 open class IQInvocation {
-    var target: AnyObject?
-    var action: Selector?
+    weak var target: AnyObject?
+    var action: Selector
     
-    init(_ target: AnyObject?, _ action: Selector?) {
+    init(_ target: AnyObject, _ action: Selector) {
         self.target = target
         self.action = action
+    }
+    
+    func invoke(from: Any) {
+        if let target = target {
+            UIApplication.shared.sendAction(action, to: target, from: from, for: UIEvent())
+        }
     }
 }

--- a/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
@@ -1,0 +1,19 @@
+//
+//  Invocation.swift
+//  IQKeyboardManagerSwift
+//
+//  Created by Metin Güler on 19.03.2018.
+//  Copyright © 2018 IQKeyboardManager. All rights reserved.
+//
+
+import Foundation
+
+open class IQInvocation {
+    var target: AnyObject?
+    var action: Selector?
+    
+    init(_ target: AnyObject?, _ action: Selector?) {
+        self.target = target
+        self.action = action
+    }
+}

--- a/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
@@ -77,7 +77,7 @@ open class IQTitleBarButtonItem: IQBarButtonItem {
     /**
      Customized Invocation to be called on title button action. titleInvocation is internally created using setTitleTarget:action: method.
      */
-    override open var invocation : (target: AnyObject?, action: Selector?)? {
+    override open var invocation : IQInvocation? {
 
         didSet {
             


### PR DESCRIPTION
# Description

Hi, i recently used the code below to assign done button custom function. But this created retain cycle and controller did not released from memory when it should. 

`textField.doneBarButton.setTarget(self, action: #selector(doCustomWork(sender:)))`

i made a little change to see if i can fix the issue. I created little class to use instead of tupple and made it weak. This change solved my issue.

> This pull request is not completed, sorry about that. i want to hear your opinions.
> i didn't had time to test objective version yet. 

Thank you.

Fixes # (issue)
-

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)