### PR TITLE
fix: view origin is not 0,should be navigationbar height

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -1083,6 +1083,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
         UIViewController *rootController = [textFieldView parentContainerViewController];
         _rootViewController = rootController;
         _topViewBeginOrigin = rootController.view.frame.origin;
+        if (([_rootViewController isKindOfClass:[UINavigationController class]] || _rootViewController.navigationController) &&
+            [_rootViewController modalPresentationStyle] != UIModalPresentationFormSheet &&
+            [_rootViewController modalPresentationStyle] != UIModalPresentationPageSheet)
+        {
+            _topViewBeginOrigin = CGPointMake(0, [self keyWindow].frame.size.height-_rootViewController.view.frame.size.height);
+        }
 
         [self showLog:[NSString stringWithFormat:@"Saving %@ beginning origin: %@",[rootController _IQDescription] ,NSStringFromCGPoint(_topViewBeginOrigin)]];
     }
@@ -1292,6 +1298,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             UIViewController *rootController = [textFieldView parentContainerViewController];
             _rootViewController = rootController;
             _topViewBeginOrigin = rootController.view.frame.origin;
+            if (([_rootViewController isKindOfClass:[UINavigationController class]] || _rootViewController.navigationController) &&
+                [_rootViewController modalPresentationStyle] != UIModalPresentationFormSheet &&
+                [_rootViewController modalPresentationStyle] != UIModalPresentationPageSheet)
+            {
+                _topViewBeginOrigin = CGPointMake(0, [self keyWindow].frame.size.height-_rootViewController.view.frame.size.height);
+            }
             
             [self showLog:[NSString stringWithFormat:@"Saving %@ beginning origin: %@",[rootController _IQDescription], NSStringFromCGPoint(_topViewBeginOrigin)]];
         }


### PR DESCRIPTION
fix: view origin is not 0,should be navigationbar height

# Description

When push to ViewController, TextField beignFirst。 The topViewBeginOrigin‘s value is {0,0,320,506}, I has to check version 5.0.0 ,find some code to fix origin value and copied. thanks!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
