### PR TITLE
Fixed IQTextView intrinsic size when placeholder text is more than 2 lines.

### DIFF
--- a/IQKeyboardManager/IQTextView/IQTextView.m
+++ b/IQKeyboardManager/IQTextView/IQTextView.m
@@ -108,13 +108,7 @@
 -(void)layoutSubviews
 {
     [super layoutSubviews];
-
-    UIEdgeInsets placeholderInsets = [self placeholderInsets];
-    CGFloat maxWidth = CGRectGetWidth(self.frame)-placeholderInsets.left-placeholderInsets.right;
-
-    CGSize expectedSize = [self.placeholderLabel sizeThatFits:CGSizeMake(maxWidth, CGRectGetHeight(self.frame)-placeholderInsets.top-placeholderInsets.bottom)];
-    
-    self.placeholderLabel.frame = CGRectMake(placeholderInsets.left, placeholderInsets.top, maxWidth, expectedSize.height);
+    self.placeholderLabel.frame = [self placeholderExpectedFrame];
 }
 
 -(void)setPlaceholder:(NSString *)placeholder
@@ -134,6 +128,16 @@
 -(UIEdgeInsets)placeholderInsets
 {
     return UIEdgeInsetsMake(self.textContainerInset.top, self.textContainerInset.left + self.textContainer.lineFragmentPadding, self.textContainerInset.bottom, self.textContainerInset.right + self.textContainer.lineFragmentPadding);
+}
+
+-(CGRect)placeholderExpectedFrame
+{
+    UIEdgeInsets placeholderInsets = [self placeholderInsets];
+    CGFloat maxWidth = CGRectGetWidth(self.frame)-placeholderInsets.left-placeholderInsets.right;
+    
+    CGSize expectedSize = [self.placeholderLabel sizeThatFits:CGSizeMake(maxWidth, CGRectGetHeight(self.frame)-placeholderInsets.top-placeholderInsets.bottom)];
+    
+    return CGRectMake(placeholderInsets.left, placeholderInsets.top, maxWidth, expectedSize.height);
 }
 
 -(UILabel*)placeholderLabel
@@ -160,6 +164,19 @@
 {
     [self refreshPlaceholder];
     return [super delegate];
+}
+
+-(CGSize)intrinsicContentSize
+{
+    if (self.hasText) {
+        return [super intrinsicContentSize];
+    }
+    
+    UIEdgeInsets placeholderInsets = [self placeholderInsets];
+    CGSize newSize = [super intrinsicContentSize];
+    newSize.height = [self placeholderExpectedFrame].size.height + placeholderInsets.top + placeholderInsets.bottom;
+    
+    return newSize;
 }
 
 @end

--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -71,6 +71,14 @@ open class IQTextView : UITextView {
     private var placeholderInsets : UIEdgeInsets {
         return UIEdgeInsets(top: self.textContainerInset.top, left: self.textContainerInset.left + self.textContainer.lineFragmentPadding, bottom: self.textContainerInset.bottom, right: self.textContainerInset.right + self.textContainer.lineFragmentPadding)
     }
+    
+    private var placeholderExpectedFrame : CGRect {
+        let placeholderInsets = self.placeholderInsets
+        let maxWidth = self.frame.width-placeholderInsets.left-placeholderInsets.right
+        let expectedSize = placeholderLabel.sizeThatFits(CGSize(width: maxWidth, height: self.frame.height-placeholderInsets.top-placeholderInsets.bottom))
+        
+        return CGRect(x: placeholderInsets.left, y: placeholderInsets.top, width: maxWidth, height: expectedSize.height)
+    }
 
     lazy var placeholderLabel: UILabel = {
         let label = UILabel()
@@ -116,11 +124,7 @@ open class IQTextView : UITextView {
     @objc override open func layoutSubviews() {
         super.layoutSubviews()
         
-        let placeholderInsets = self.placeholderInsets
-        let maxWidth = self.frame.width-placeholderInsets.left-placeholderInsets.right
-        let expectedSize = placeholderLabel.sizeThatFits(CGSize(width: maxWidth, height: self.frame.height-placeholderInsets.top-placeholderInsets.bottom))
-        
-        placeholderLabel.frame = CGRect(x: placeholderInsets.left, y: placeholderInsets.top, width: maxWidth, height: expectedSize.height)
+        placeholderLabel.frame = placeholderExpectedFrame
     }
     
     @objc internal func refreshPlaceholder() {
@@ -170,6 +174,18 @@ open class IQTextView : UITextView {
         set {
             super.delegate = newValue
         }
+    }
+    
+    @objc override open var intrinsicContentSize: CGSize {
+        guard !hasText else {
+            return super.intrinsicContentSize
+        }
+        
+        var newSize = super.intrinsicContentSize
+        let placeholderInsets = self.placeholderInsets
+        newSize.height = placeholderExpectedFrame.height + placeholderInsets.top + placeholderInsets.bottom
+        
+        return newSize
     }
 }
 


### PR DESCRIPTION
# Description
Fixed IQTextView intrinsic size when placeholder text is more than 2 lines.

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
