### PR TITLE
Set IQTextView's placeholder as attributed string

### DIFF
--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -120,6 +120,18 @@ open class IQTextView : UITextView {
             refreshPlaceholder()
         }
     }
+
+    /** @abstract To set textView's placeholder attributed text. Default is nil.    */
+    open var attributedPlaceholder: NSAttributedString? {
+        get {
+            return placeholderLabel.attributedText
+        }
+
+        set {
+            placeholderLabel.attributedText = newValue
+            refreshPlaceholder()
+        }
+    }
     
     @objc override open func layoutSubviews() {
         super.layoutSubviews()


### PR DESCRIPTION
# Description

Add an ability to set as attributed string. Sometimes it's required to change placeholder's font/size too.

Added support only for Swift, cause Obj-C code is messy, and doesn't work for toolbar. Changes for Obj-C are welcome.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
