### PR TITLE
add prefix to method and property names in system class extensions

### DIFF
--- a/Demo/Objective_C_Demo/ViewController/ManualToolbarViewController.m
+++ b/Demo/Objective_C_Demo/ViewController/ManualToolbarViewController.m
@@ -42,21 +42,21 @@
 {
     [super viewDidLoad];
     
-    [textField1 addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
-    textField1.keyboardToolbar.previousBarButton.enabled = NO;
-    textField1.keyboardToolbar.nextBarButton.enabled = YES;
+    [textField1 iq_addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
+    textField1.iq_keyboardToolbar.previousBarButton.enabled = NO;
+    textField1.iq_keyboardToolbar.nextBarButton.enabled = YES;
 
     
-    [textField2 addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
-    textField2.keyboardToolbar.previousBarButton.enabled = YES;
-    textField2.keyboardToolbar.nextBarButton.enabled = NO;
+    [textField2 iq_addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
+    textField2.iq_keyboardToolbar.previousBarButton.enabled = YES;
+    textField2.iq_keyboardToolbar.nextBarButton.enabled = NO;
 
-    [textView3 addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
+    [textView3 iq_addPreviousNextDoneOnKeyboardWithTarget:self previousAction:@selector(previousAction:) nextAction:@selector(nextAction:) doneAction:@selector(doneAction:) shouldShowPlaceholder:YES];
 
-    [self.textField4.keyboardToolbar.titleBarButton setTarget:self action:@selector(titleAction:)];
-    self.textField4.toolbarPlaceholder = @"Saved Users";
+    [self.textField4.iq_keyboardToolbar.titleBarButton setTarget:self action:@selector(titleAction:)];
+    self.textField4.iq_toolbarPlaceholder = @"Saved Users";
     
-    [self.textField4 addDoneOnKeyboardWithTarget:self action:@selector(doneAction:) shouldShowPlaceholder:YES];
+    [self.textField4 iq_addDoneOnKeyboardWithTarget:self action:@selector(doneAction:) shouldShowPlaceholder:YES];
     
     textField5.inputAccessoryView = [[UIView alloc] init];
 }

--- a/Demo/Objective_C_Demo/ViewController/NavigationBarViewController.m
+++ b/Demo/Objective_C_Demo/ViewController/NavigationBarViewController.m
@@ -29,7 +29,7 @@
 {
     [super viewDidLoad];
     
-    textField3.toolbarPlaceholder = @"This is the customised placeholder title for displaying as toolbar title";
+    textField3.iq_toolbarPlaceholder = @"This is the customised placeholder title for displaying as toolbar title";
     
     returnKeyHandler = [[IQKeyboardReturnKeyHandler alloc] initWithViewController:self];
     [returnKeyHandler setLastTextFieldReturnKeyType:UIReturnKeyDone];
@@ -42,7 +42,7 @@
 
 - (IBAction)shouldHideTitle:(UISwitch *)sender
 {
-    textField2.shouldHideToolbarPlaceholder = !textField2.shouldHideToolbarPlaceholder;
+    textField2.iq_shouldHideToolbarPlaceholder = !textField2.iq_shouldHideToolbarPlaceholder;
 }
 
 -(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender

--- a/Demo/Objective_C_Demo/ViewController/TextFieldViewController.m
+++ b/Demo/Objective_C_Demo/ViewController/TextFieldViewController.m
@@ -45,11 +45,11 @@
 {
     [super viewDidLoad];
     
-    [textField3.keyboardToolbar.previousBarButton setTarget:self action:@selector(previousAction:)];
-    [textField3.keyboardToolbar.nextBarButton setTarget:self action:@selector(nextAction:)];
-    [textField3.keyboardToolbar.doneBarButton setTarget:self action:@selector(doneAction:)];
+    [textField3.iq_keyboardToolbar.previousBarButton setTarget:self action:@selector(previousAction:)];
+    [textField3.iq_keyboardToolbar.nextBarButton setTarget:self action:@selector(nextAction:)];
+    [textField3.iq_keyboardToolbar.doneBarButton setTarget:self action:@selector(doneAction:)];
     
-    dropDownTextField.keyboardDistanceFromTextField = 150;
+    dropDownTextField.iq_keyboardDistanceFromTextField = 150;
     
     [dropDownTextField setItemList:@[@"Zero Line Of Code",
                                      @"No More UIScrollView",

--- a/IQKeyboardManager/Categories/IQNSArray+Sort.h
+++ b/IQKeyboardManager/Categories/IQNSArray+Sort.h
@@ -37,11 +37,11 @@
 /**
  Returns the array by sorting the UIView's by their tag property.
  */
-@property (nonatomic, readonly, copy) NSArray<__kindof UIView*> * _Nonnull sortedArrayByTag;
+@property (nonatomic, readonly, copy) NSArray<__kindof UIView*> * _Nonnull iq_sortedArrayByTag;
 
 /**
  Returns the array by sorting the UIView's by their tag property.
  */
-@property (nonatomic, readonly, copy) NSArray<__kindof UIView*> * _Nonnull sortedArrayByPosition;
+@property (nonatomic, readonly, copy) NSArray<__kindof UIView*> * _Nonnull iq_sortedArrayByPosition;
 
 @end

--- a/IQKeyboardManager/Categories/IQNSArray+Sort.m
+++ b/IQKeyboardManager/Categories/IQNSArray+Sort.m
@@ -28,7 +28,7 @@
 
 @implementation NSArray (IQ_NSArray_Sort)
 
-- (NSArray<UIView*>*)sortedArrayByTag
+- (NSArray<UIView*>*)iq_sortedArrayByTag
 {
     return [self sortedArrayUsingComparator:^NSComparisonResult(UIView *view1, UIView *view2) {
         
@@ -45,7 +45,7 @@
     }];
 }
 
-- (NSArray<UIView*>*)sortedArrayByPosition
+- (NSArray<UIView*>*)iq_sortedArrayByPosition
 {
     return [self sortedArrayUsingComparator:^NSComparisonResult(UIView *view1, UIView *view2) {
         

--- a/IQKeyboardManager/Categories/IQUIScrollView+Additions.h
+++ b/IQKeyboardManager/Categories/IQUIScrollView+Additions.h
@@ -29,12 +29,12 @@
 /**
  If YES, then scrollview will ignore scrolling (simply not scroll it) for adjusting textfield position. Default is NO.
  */
-@property(nonatomic, assign) BOOL shouldIgnoreScrollingAdjustment;
+@property(nonatomic, assign) BOOL iq_shouldIgnoreScrollingAdjustment;
 
 /**
  Restore scrollViewContentOffset when resigning from scrollView. Default is NO.
  */
-@property(nonatomic, assign) BOOL shouldRestoreScrollViewContentOffset;
+@property(nonatomic, assign) BOOL iq_shouldRestoreScrollViewContentOffset;
 
 
 @end

--- a/IQKeyboardManager/Categories/IQUIScrollView+Additions.m
+++ b/IQKeyboardManager/Categories/IQUIScrollView+Additions.m
@@ -26,26 +26,26 @@
 
 @implementation UIScrollView (Additions)
 
--(void)setShouldIgnoreScrollingAdjustment:(BOOL)shouldIgnoreScrollingAdjustment
+-(void)setIq_shouldIgnoreScrollingAdjustment:(BOOL)shouldIgnoreScrollingAdjustment
 {
-    objc_setAssociatedObject(self, @selector(shouldIgnoreScrollingAdjustment), @(shouldIgnoreScrollingAdjustment), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_shouldIgnoreScrollingAdjustment), @(shouldIgnoreScrollingAdjustment), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(BOOL)shouldIgnoreScrollingAdjustment
+-(BOOL)iq_shouldIgnoreScrollingAdjustment
 {
-    NSNumber *shouldIgnoreScrollingAdjustment = objc_getAssociatedObject(self, @selector(shouldIgnoreScrollingAdjustment));
+    NSNumber *shouldIgnoreScrollingAdjustment = objc_getAssociatedObject(self, @selector(iq_shouldIgnoreScrollingAdjustment));
     
     return [shouldIgnoreScrollingAdjustment boolValue];
 }
 
--(void)setShouldRestoreScrollViewContentOffset:(BOOL)shouldRestoreScrollViewContentOffset
+-(void)setIq_shouldRestoreScrollViewContentOffset:(BOOL)shouldRestoreScrollViewContentOffset
 {
-    objc_setAssociatedObject(self, @selector(shouldRestoreScrollViewContentOffset), @(shouldRestoreScrollViewContentOffset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_shouldRestoreScrollViewContentOffset), @(shouldRestoreScrollViewContentOffset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(BOOL)shouldRestoreScrollViewContentOffset
+-(BOOL)iq_shouldRestoreScrollViewContentOffset
 {
-    NSNumber *shouldRestoreScrollViewContentOffset = objc_getAssociatedObject(self, @selector(shouldRestoreScrollViewContentOffset));
+    NSNumber *shouldRestoreScrollViewContentOffset = objc_getAssociatedObject(self, @selector(iq_shouldRestoreScrollViewContentOffset));
     
     return [shouldRestoreScrollViewContentOffset boolValue];
 }

--- a/IQKeyboardManager/Categories/IQUITextFieldView+Additions.h
+++ b/IQKeyboardManager/Categories/IQUITextFieldView+Additions.h
@@ -33,12 +33,12 @@
 /**
  To set customized distance from keyboard for textField/textView. Can't be less than zero
  */
-@property(nonatomic, assign) CGFloat keyboardDistanceFromTextField;
+@property(nonatomic, assign) CGFloat iq_keyboardDistanceFromTextField;
 
 /**
  If shouldIgnoreSwitchingByNextPrevious is YES then library will ignore this textField/textView while moving to other textField/textView using keyboard toolbar next previous buttons. Default is NO
  */
-@property(nonatomic, assign) BOOL ignoreSwitchingByNextPrevious;
+@property(nonatomic, assign) BOOL iq_ignoreSwitchingByNextPrevious;
 
 ///**
 // Override Enable/disable managing distance between keyboard and textField behaviour for this particular textField.
@@ -48,7 +48,7 @@
 /**
  Override resigns Keyboard on touching outside of UITextField/View behaviour for this particular textField.
  */
-@property(nonatomic, assign) IQEnableMode shouldResignOnTouchOutsideMode;
+@property(nonatomic, assign) IQEnableMode iq_shouldResignOnTouchOutsideMode;
 
 @end
 

--- a/IQKeyboardManager/Categories/IQUITextFieldView+Additions.m
+++ b/IQKeyboardManager/Categories/IQUITextFieldView+Additions.m
@@ -26,29 +26,29 @@
 
 @implementation UIView (Additions)
 
--(void)setKeyboardDistanceFromTextField:(CGFloat)keyboardDistanceFromTextField
+-(void)setIq_keyboardDistanceFromTextField:(CGFloat)keyboardDistanceFromTextField
 {
     //Can't be less than zero. Minimum is zero.
     keyboardDistanceFromTextField = MAX(keyboardDistanceFromTextField, 0);
     
-    objc_setAssociatedObject(self, @selector(keyboardDistanceFromTextField), @(keyboardDistanceFromTextField), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_keyboardDistanceFromTextField), @(keyboardDistanceFromTextField), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(CGFloat)keyboardDistanceFromTextField
+-(CGFloat)iq_keyboardDistanceFromTextField
 {
-    NSNumber *keyboardDistanceFromTextField = objc_getAssociatedObject(self, @selector(keyboardDistanceFromTextField));
+    NSNumber *keyboardDistanceFromTextField = objc_getAssociatedObject(self, @selector(iq_keyboardDistanceFromTextField));
     
     return (keyboardDistanceFromTextField)?[keyboardDistanceFromTextField floatValue]:kIQUseDefaultKeyboardDistance;
 }
 
--(void)setIgnoreSwitchingByNextPrevious:(BOOL)ignoreSwitchingByNextPrevious
+-(void)setIq_ignoreSwitchingByNextPrevious:(BOOL)ignoreSwitchingByNextPrevious
 {
-    objc_setAssociatedObject(self, @selector(ignoreSwitchingByNextPrevious), @(ignoreSwitchingByNextPrevious), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_ignoreSwitchingByNextPrevious), @(ignoreSwitchingByNextPrevious), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(BOOL)ignoreSwitchingByNextPrevious
+-(BOOL)iq_ignoreSwitchingByNextPrevious
 {
-    NSNumber *ignoreSwitchingByNextPrevious = objc_getAssociatedObject(self, @selector(ignoreSwitchingByNextPrevious));
+    NSNumber *ignoreSwitchingByNextPrevious = objc_getAssociatedObject(self, @selector(iq_ignoreSwitchingByNextPrevious));
     
     return [ignoreSwitchingByNextPrevious boolValue];
 }
@@ -65,14 +65,14 @@
 //    return [enableMode unsignedIntegerValue];
 //}
 
--(void)setShouldResignOnTouchOutsideMode:(IQEnableMode)shouldResignOnTouchOutsideMode
+-(void)setIq_shouldResignOnTouchOutsideMode:(IQEnableMode)shouldResignOnTouchOutsideMode
 {
-    objc_setAssociatedObject(self, @selector(shouldResignOnTouchOutsideMode), @(shouldResignOnTouchOutsideMode), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_shouldResignOnTouchOutsideMode), @(shouldResignOnTouchOutsideMode), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(IQEnableMode)shouldResignOnTouchOutsideMode
+-(IQEnableMode)iq_shouldResignOnTouchOutsideMode
 {
-    NSNumber *shouldResignOnTouchOutsideMode = objc_getAssociatedObject(self, @selector(shouldResignOnTouchOutsideMode));
+    NSNumber *shouldResignOnTouchOutsideMode = objc_getAssociatedObject(self, @selector(iq_shouldResignOnTouchOutsideMode));
     
     return [shouldResignOnTouchOutsideMode unsignedIntegerValue];
 }

--- a/IQKeyboardManager/Categories/IQUIView+Hierarchy.h
+++ b/IQKeyboardManager/Categories/IQUIView+Hierarchy.h
@@ -39,17 +39,17 @@
 /**
  Returns the UIViewController object that manages the receiver.
  */
-@property (nullable, nonatomic, readonly, strong) UIViewController *viewContainingController;
+@property (nullable, nonatomic, readonly, strong) UIViewController *iq_viewContainingController;
 
 /**
  Returns the topMost UIViewController object in hierarchy.
  */
-@property (nullable, nonatomic, readonly, strong) UIViewController *topMostController;
+@property (nullable, nonatomic, readonly, strong) UIViewController *iq_topMostController;
 
 /**
  Returns the UIViewController object that is actually the parent of this object. Most of the time it's the viewController object which actually contains it, but result may be different if it's viewController is added as childViewController of another viewController.
  */
-@property (nullable, nonatomic, readonly, strong) UIViewController *parentContainerViewController;
+@property (nullable, nonatomic, readonly, strong) UIViewController *iq_parentContainerViewController;
 
 ///-----------------------------------
 /// @name Superviews/Subviews/Siglings
@@ -58,17 +58,17 @@
 /**
  Returns the superView of provided class type.
  */
--(nullable UIView*)superviewOfClassType:(nonnull Class)classType;
+-(nullable UIView*)iq_superviewOfClassType:(nonnull Class)classType;
 
 /**
  Returns all siblings of the receiver which canBecomeFirstResponder.
  */
-@property (nonnull, nonatomic, readonly, copy) NSArray<__kindof UIView*> *responderSiblings;
+@property (nonnull, nonatomic, readonly, copy) NSArray<__kindof UIView*> *iq_responderSiblings;
 
 /**
  Returns all deep subViews of the receiver which canBecomeFirstResponder.
  */
-@property (nonnull, nonatomic, readonly, copy) NSArray<__kindof UIView*> *deepResponderViews;
+@property (nonnull, nonatomic, readonly, copy) NSArray<__kindof UIView*> *iq_deepResponderViews;
 
 ///-------------------------
 /// @name Special TextFields
@@ -77,12 +77,12 @@
 /**
  Returns searchBar if receiver object is UISearchBarTextField, otherwise return nil.
  */
-@property (nullable, nonatomic, readonly) UISearchBar *searchBar;
+@property (nullable, nonatomic, readonly) UISearchBar *iq_searchBar;
 
 /**
  Returns YES if the receiver object is UIAlertSheetTextField, otherwise return NO.
  */
-@property (nonatomic, getter=isAlertViewTextField, readonly) BOOL alertViewTextField;
+@property (nonatomic, getter=isAlertViewTextField, readonly) BOOL iq_alertViewTextField;
 
 ///----------------
 /// @name Transform
@@ -91,7 +91,7 @@
 /**
  Returns current view transform with respect to the 'toView'.
  */
--(CGAffineTransform)convertTransformToView:(nullable UIView*)toView;
+-(CGAffineTransform)iq_convertTransformToView:(nullable UIView*)toView;
 
 ///-----------------
 /// @name Hierarchy
@@ -100,17 +100,17 @@
 /**
  Returns a string that represent the information about it's subview's hierarchy. You can use this method to debug the subview's positions.
  */
-@property (nonnull, nonatomic, readonly, copy) NSString *subHierarchy;
+@property (nonnull, nonatomic, readonly, copy) NSString *iq_subHierarchy;
 
 /**
  Returns an string that represent the information about it's upper hierarchy. You can use this method to debug the superview's positions.
  */
-@property (nonnull, nonatomic, readonly, copy) NSString *superHierarchy;
+@property (nonnull, nonatomic, readonly, copy) NSString *iq_superHierarchy;
 
 /**
  Returns an string that represent the information about it's frame positions. You can use this method to debug self positions.
  */
-@property (nonnull, nonatomic, readonly, copy) NSString *debugHierarchy;
+@property (nonnull, nonatomic, readonly, copy) NSString *iq_debugHierarchy;
 
 @end
 

--- a/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
@@ -41,7 +41,7 @@
 
 @implementation UIView (IQ_UIView_Hierarchy)
 
--(UIViewController*)viewContainingController
+-(UIViewController*)iq_viewContainingController
 {
     UIResponder *nextResponder =  self;
     
@@ -57,7 +57,7 @@
     return nil;
 }
 
--(UIViewController *)topMostController
+-(UIViewController *)iq_topMostController
 {
     NSMutableArray<UIViewController*> *controllersHierarchy = [[NSMutableArray alloc] init];
     
@@ -74,7 +74,7 @@
         [controllersHierarchy addObject:topController];
     }
     
-    UIViewController *matchController = [self viewContainingController];
+    UIViewController *matchController = [self iq_viewContainingController];
     
     while (matchController && [controllersHierarchy containsObject:matchController] == NO)
     {
@@ -88,9 +88,9 @@
     return matchController;
 }
 
--(UIViewController *)parentContainerViewController
+-(UIViewController *)iq_parentContainerViewController
 {
-    UIViewController *matchController = [self viewContainingController];
+    UIViewController *matchController = [self iq_viewContainingController];
     
     UIViewController *parentContainerViewController = nil;
     
@@ -156,7 +156,7 @@
     return finalController;
 }
 
--(UIView*)superviewOfClassType:(Class)classType
+-(UIView*)iq_superviewOfClassType:(Class)classType
 {
     UIView *superview = self.superview;
     
@@ -206,13 +206,13 @@
 
     if (_IQcanBecomeFirstResponder == YES)
     {
-        _IQcanBecomeFirstResponder = ([self isUserInteractionEnabled] && ![self isHidden] && [self alpha]!=0.0 && ![self isAlertViewTextField]  && !self.searchBar);
+        _IQcanBecomeFirstResponder = ([self isUserInteractionEnabled] && ![self isHidden] && [self alpha]!=0.0 && ![self isAlertViewTextField]  && !self.iq_searchBar);
     }
     
     return _IQcanBecomeFirstResponder;
 }
 
-- (NSArray<UIView*>*)responderSiblings
+- (NSArray<UIView*>*)iq_responderSiblings
 {
     //	Getting all siblings
     NSArray<UIView*> *siblings = self.superview.subviews;
@@ -221,19 +221,19 @@
     NSMutableArray<UIView*> *tempTextFields = [[NSMutableArray alloc] init];
     
     for (UIView *textField in siblings)
-        if ((textField == self || textField.ignoreSwitchingByNextPrevious == NO) && [textField _IQcanBecomeFirstResponder])
+        if ((textField == self || textField.iq_ignoreSwitchingByNextPrevious == NO) && [textField _IQcanBecomeFirstResponder])
             [tempTextFields addObject:textField];
     
     return tempTextFields;
 }
 
-- (NSArray<UIView*>*)deepResponderViews
+- (NSArray<UIView*>*)iq_deepResponderViews
 {
     NSMutableArray<UIView*> *textFields = [[NSMutableArray alloc] init];
     
     for (UIView *textField in self.subviews)
     {
-        if ((textField == self || textField.ignoreSwitchingByNextPrevious == NO) && [textField _IQcanBecomeFirstResponder])
+        if ((textField == self || textField.iq_ignoreSwitchingByNextPrevious == NO) && [textField _IQcanBecomeFirstResponder])
         {
             [textFields addObject:textField];
         }
@@ -242,7 +242,7 @@
         //Uncommented else (Bug ID: #625)
         if (textField.subviews.count && [textField isUserInteractionEnabled] && ![textField isHidden] && [textField alpha]!=0.0)
         {
-            [textFields addObjectsFromArray:[textField deepResponderViews]];
+            [textFields addObjectsFromArray:[textField iq_deepResponderViews]];
         }
     }
 
@@ -272,7 +272,7 @@
     return textFields;
 }
 
--(CGAffineTransform)convertTransformToView:(UIView*)toView
+-(CGAffineTransform)iq_convertTransformToView:(UIView*)toView
 {
     if (toView == nil)
     {
@@ -285,7 +285,7 @@
     {
         UIView *superView = [self superview];
         
-        if (superView)  myTransform = CGAffineTransformConcat(self.transform, [superView convertTransformToView:nil]);
+        if (superView)  myTransform = CGAffineTransformConcat(self.transform, [superView iq_convertTransformToView:nil]);
         else            myTransform = self.transform;
     }
     
@@ -295,7 +295,7 @@
     {
         UIView *superView = [toView superview];
         
-        if (superView)  viewTransform = CGAffineTransformConcat(toView.transform, [superView convertTransformToView:nil]);
+        if (superView)  viewTransform = CGAffineTransformConcat(toView.transform, [superView iq_convertTransformToView:nil]);
         else if (toView)  viewTransform = toView.transform;
     }
     
@@ -315,30 +315,30 @@
     return depth;
 }
 
-- (NSString *)subHierarchy
+- (NSString *)iq_subHierarchy
 {
     NSMutableString *debugInfo = [[NSMutableString alloc] initWithString:@"\n"];
     NSInteger depth = [self depth];
     
     for (int counter = 0; counter < depth; counter ++)  [debugInfo appendString:@"|  "];
     
-    [debugInfo appendString:[self debugHierarchy]];
+    [debugInfo appendString:[self iq_debugHierarchy]];
     
     for (UIView *subview in self.subviews)
     {
-        [debugInfo appendString:[subview subHierarchy]];
+        [debugInfo appendString:[subview iq_subHierarchy]];
     }
     
     return debugInfo;
 }
 
-- (NSString *)superHierarchy
+- (NSString *)iq_superHierarchy
 {
     NSMutableString *debugInfo = [[NSMutableString alloc] init];
 
     if (self.superview)
     {
-        [debugInfo appendString:[self.superview superHierarchy]];
+        [debugInfo appendString:[self.superview iq_superHierarchy]];
     }
     else
     {
@@ -349,14 +349,14 @@
     
     for (int counter = 0; counter < depth; counter ++)  [debugInfo appendString:@"|  "];
     
-    [debugInfo appendString:[self debugHierarchy]];
+    [debugInfo appendString:[self iq_debugHierarchy]];
 
     [debugInfo appendString:@"\n"];
     
     return debugInfo;
 }
 
--(NSString *)debugHierarchy
+-(NSString *)iq_debugHierarchy
 {
     NSMutableString *debugInfo = [[NSMutableString alloc] init];
 
@@ -376,7 +376,7 @@
     return debugInfo;
 }
 
--(UISearchBar *)searchBar
+-(UISearchBar *)iq_searchBar
 {
     UIResponder *searchBar = [self nextResponder];
     
@@ -399,7 +399,7 @@
 
 -(BOOL)isAlertViewTextField
 {
-    UIResponder *alertViewController = [self viewContainingController];
+    UIResponder *alertViewController = [self iq_viewContainingController];
     
     BOOL isAlertViewTextField = NO;
     while (alertViewController && isAlertViewTextField == NO)

--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -235,8 +235,8 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             {
                 //If you experience exception breakpoint issue at below line then try these solutions https://stackoverflow.com/questions/27375640/all-exception-break-point-is-stopping-for-no-reason-on-simulator
                 UITextField *view = [[UITextField alloc] init];
-                [view addDoneOnKeyboardWithTarget:nil action:nil];
-                [view addPreviousNextDoneOnKeyboardWithTarget:nil previousAction:nil nextAction:nil doneAction:nil];
+                [view iq_addDoneOnKeyboardWithTarget:nil action:nil];
+                [view iq_addPreviousNextDoneOnKeyboardWithTarget:nil previousAction:nil nextAction:nil doneAction:nil];
             }
             
             //Initializing disabled classes Set.
@@ -340,7 +340,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 //    }
 //    else
     {
-        UIViewController *textFieldViewController = [_textFieldView viewContainingController];
+        UIViewController *textFieldViewController = [_textFieldView iq_viewContainingController];
         
         if (textFieldViewController)
         {
@@ -422,7 +422,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     BOOL shouldResignOnTouchOutside = _shouldResignOnTouchOutside;
     
     UIView *textFieldView = _textFieldView;
-    IQEnableMode enableMode = textFieldView.shouldResignOnTouchOutsideMode;
+    IQEnableMode enableMode = textFieldView.iq_shouldResignOnTouchOutsideMode;
     
     if (enableMode == IQEnableModeEnabled)
     {
@@ -434,7 +434,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     }
     else
     {
-        UIViewController *textFieldViewController = [textFieldView viewContainingController];
+        UIViewController *textFieldViewController = [textFieldView iq_viewContainingController];
         
         if (textFieldViewController)
         {
@@ -504,7 +504,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 {
     BOOL enableAutoToolbar = _enableAutoToolbar;
     
-    UIViewController *textFieldViewController = [_textFieldView viewContainingController];
+    UIViewController *textFieldViewController = [_textFieldView iq_viewContainingController];
     
     if (textFieldViewController)
     {
@@ -623,14 +623,14 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     CGPoint rootViewOrigin = rootController.view.frame.origin;
 
     //Maintain keyboardDistanceFromTextField
-    CGFloat specialKeyboardDistanceFromTextField = textFieldView.keyboardDistanceFromTextField;
+    CGFloat specialKeyboardDistanceFromTextField = textFieldView.iq_keyboardDistanceFromTextField;
 
     {
-        UISearchBar *searchBar = textFieldView.searchBar;
+        UISearchBar *searchBar = textFieldView.iq_searchBar;
         
         if (searchBar)
         {
-            specialKeyboardDistanceFromTextField = searchBar.keyboardDistanceFromTextField;
+            specialKeyboardDistanceFromTextField = searchBar.iq_keyboardDistanceFromTextField;
         }
     }
     
@@ -652,12 +652,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     [self showLog:[NSString stringWithFormat:@"Need to move: %.2f",move]];
 
     UIScrollView *superScrollView = nil;
-    UIScrollView *superView = (UIScrollView*)[textFieldView superviewOfClassType:[UIScrollView class]];
+    UIScrollView *superView = (UIScrollView*)[textFieldView iq_superviewOfClassType:[UIScrollView class]];
 
     //Getting UIScrollView whose scrolling is enabled.    //  (Bug ID: #285)
     while (superView)
     {
-        if (superView.isScrollEnabled && superView.shouldIgnoreScrollingAdjustment == NO)
+        if (superView.isScrollEnabled && superView.iq_shouldIgnoreScrollingAdjustment == NO)
         {
             superScrollView = superView;
             break;
@@ -665,7 +665,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
         else
         {
             //  Getting it's superScrollView.   //  (Enhancement ID: #21, #24)
-            superView = (UIScrollView*)[superView superviewOfClassType:[UIScrollView class]];
+            superView = (UIScrollView*)[superView iq_superviewOfClassType:[UIScrollView class]];
         }
     }
     
@@ -688,7 +688,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 strongLastScrollView.scrollIndicatorInsets = strongSelf.startingScrollIndicatorInsets;
             } completion:NULL];
             
-            if (_lastScrollView.shouldRestoreScrollViewContentOffset)
+            if (_lastScrollView.iq_shouldRestoreScrollViewContentOffset)
             {
                 [_lastScrollView setContentOffset:_startingContentOffset animated:UIView.areAnimationsEnabled];
             }
@@ -714,7 +714,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 strongLastScrollView.scrollIndicatorInsets = strongSelf.startingScrollIndicatorInsets;
             } completion:NULL];
 
-            if (_lastScrollView.shouldRestoreScrollViewContentOffset)
+            if (_lastScrollView.iq_shouldRestoreScrollViewContentOffset)
             {
                 [_lastScrollView setContentOffset:_startingContentOffset animated:UIView.areAnimationsEnabled];
             }
@@ -753,12 +753,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                    (move>0?(move > (-superScrollView.contentOffset.y-superScrollView.contentInset.top)):superScrollView.contentOffset.y>0) )
             {
                 UIScrollView *nextScrollView = nil;
-                UIScrollView *tempScrollView = (UIScrollView*)[superScrollView superviewOfClassType:[UIScrollView class]];
+                UIScrollView *tempScrollView = (UIScrollView*)[superScrollView iq_superviewOfClassType:[UIScrollView class]];
                 
                 //Getting UIScrollView whose scrolling is enabled.    //  (Bug ID: #285)
                 while (tempScrollView)
                 {
-                    if (tempScrollView.isScrollEnabled && tempScrollView.shouldIgnoreScrollingAdjustment == NO)
+                    if (tempScrollView.isScrollEnabled && tempScrollView.iq_shouldIgnoreScrollingAdjustment == NO)
                     {
                         nextScrollView = tempScrollView;
                         break;
@@ -766,7 +766,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                     else
                     {
                         //  Getting it's superScrollView.   //  (Enhancement ID: #21, #24)
-                        tempScrollView = (UIScrollView*)[tempScrollView superviewOfClassType:[UIScrollView class]];
+                        tempScrollView = (UIScrollView*)[tempScrollView iq_superviewOfClassType:[UIScrollView class]];
                     }
                 }
 
@@ -1093,7 +1093,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     if (textFieldView && CGPointEqualToPoint(_topViewBeginOrigin, kIQCGPointInvalid))    //  (Bug ID: #5)
     {
         //  keyboard is not showing(At the beginning only). We should save rootViewRect.
-        UIViewController *rootController = [textFieldView parentContainerViewController];
+        UIViewController *rootController = [textFieldView iq_parentContainerViewController];
         _rootViewController = rootController;
         
         if (_rootViewControllerWhilePopGestureRecognizerActive == _rootViewController)
@@ -1139,7 +1139,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     UIView *textFieldView = _textFieldView;
 
     //  Getting topMost ViewController.
-    UIViewController *controller = [textFieldView topMostController];
+    UIViewController *controller = [textFieldView iq_topMostController];
 
     //If _textFieldView viewController is presented as formSheet, then adjustPosition again because iOS internally update formSheet frame on keyboardShown. (Bug ID: #37, #74, #76)
     if (_keyboardShowing == YES &&
@@ -1192,7 +1192,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             strongSelf.lastScrollView.contentInset = strongSelf.startingContentInsets;
             strongSelf.lastScrollView.scrollIndicatorInsets = strongSelf.startingScrollIndicatorInsets;
             
-            if (strongSelf.lastScrollView.shouldRestoreScrollViewContentOffset)
+            if (strongSelf.lastScrollView.iq_shouldRestoreScrollViewContentOffset)
             {
                 strongSelf.lastScrollView.contentOffset = strongSelf.startingContentOffset;
             }
@@ -1214,7 +1214,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                     
                     [self showLog:[NSString stringWithFormat:@"Restoring %@ contentOffset to : %@",[superscrollView _IQDescription],NSStringFromCGPoint(superscrollView.contentOffset)]];
                 }
-            } while ((superscrollView = (UIScrollView*)[superscrollView superviewOfClassType:[UIScrollView class]]));
+            } while ((superscrollView = (UIScrollView*)[superscrollView iq_superviewOfClassType:[UIScrollView class]]));
 
         } completion:NULL];
     }
@@ -1313,7 +1313,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
         if (CGPointEqualToPoint(_topViewBeginOrigin, kIQCGPointInvalid))    //  (Bug ID: #5)
         {
             //  keyboard is not showing(At the beginning only).
-            UIViewController *rootController = [textFieldView parentContainerViewController];
+            UIViewController *rootController = [textFieldView iq_parentContainerViewController];
             _rootViewController = rootController;
             
             if (_rootViewControllerWhilePopGestureRecognizerActive == _rootViewController)
@@ -1629,7 +1629,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     //If find any consider responderView in it's upper hierarchy then will get deepResponderView.
     for (Class consideredClass in _toolbarPreviousNextAllowedClasses)
     {
-        superConsideredView = [textFieldView superviewOfClassType:consideredClass];
+        superConsideredView = [textFieldView iq_superviewOfClassType:consideredClass];
         
         if (superConsideredView)
             break;
@@ -1638,12 +1638,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     //If there is a superConsideredView in view's hierarchy, then fetching all it's subview that responds. No sorting for superConsideredView, it's by subView position.    (Enhancement ID: #22)
     if (superConsideredView)
     {
-        return [superConsideredView deepResponderViews];
+        return [superConsideredView iq_deepResponderViews];
     }
     //Otherwise fetching all the siblings
     else
     {
-        NSArray<UIView*> *textFields = [textFieldView responderSiblings];
+        NSArray<UIView*> *textFields = [textFieldView iq_responderSiblings];
         
         //Sorting textFields according to behaviour
         switch (_toolbarManageBehaviour)
@@ -1655,12 +1655,12 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 
                 //If autoToolbar behaviour is by tag, then sorting it according to tag property.
             case IQAutoToolbarByTag:
-                return [textFields sortedArrayByTag];
+                return [textFields iq_sortedArrayByTag];
                 break;
                 
                 //If autoToolbar behaviour is by tag, then sorting it according to tag property.
             case IQAutoToolbarByPosition:
-                return [textFields sortedArrayByPosition];
+                return [textFields iq_sortedArrayByPosition];
                 break;
             default:
                 return nil;
@@ -1712,7 +1712,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             //    If only one object is found, then adding only Done button.
             if ((siblings.count==1 && self.previousNextDisplayMode == IQPreviousNextDisplayModeDefault) || self.previousNextDisplayMode == IQPreviousNextDisplayModeAlwaysHide)
             {
-                [textField addKeyboardToolbarWithTarget:self titleText:(_shouldShowToolbarPlaceholder ? textField.drawingToolbarPlaceholder : nil) rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
+                [textField iq_addKeyboardToolbarWithTarget:self titleText:(_shouldShowToolbarPlaceholder ? textField.iq_drawingToolbarPlaceholder : nil) rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
 
                 textField.inputAccessoryView.tag = kIQDoneButtonToolbarTag; //  (Bug ID: #78)
             }
@@ -1733,7 +1733,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 }
                 else
                 {
-                    prevConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardPreviousImage] action:@selector(previousAction:)];
+                    prevConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardPreviousImage] action:@selector(previousAction:)];
                 }
                 
                 IQBarButtonItemConfiguration *nextConfiguration = nil;
@@ -1750,15 +1750,15 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 }
                 else
                 {
-                    nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardNextImage] action:@selector(nextAction:)];
+                    nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardNextImage] action:@selector(nextAction:)];
                 }
 
-                [textField addKeyboardToolbarWithTarget:self titleText:(_shouldShowToolbarPlaceholder ? textField.drawingToolbarPlaceholder : nil) rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:prevConfiguration nextBarButtonConfiguration:nextConfiguration];
+                [textField iq_addKeyboardToolbarWithTarget:self titleText:(_shouldShowToolbarPlaceholder ? textField.iq_drawingToolbarPlaceholder : nil) rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:prevConfiguration nextBarButtonConfiguration:nextConfiguration];
 
                 textField.inputAccessoryView.tag = kIQPreviousNextButtonToolbarTag; //  (Bug ID: #78)
             }
             
-            IQToolbar *toolbar = textField.keyboardToolbar;
+            IQToolbar *toolbar = textField.iq_keyboardToolbar;
             
             //Bar style according to keyboard appearance
             if ([textField respondsToSelector:@selector(keyboardAppearance)])
@@ -1796,13 +1796,13 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 
                 //If need to show placeholder
                 if (_shouldShowToolbarPlaceholder &&
-                    textField.shouldHideToolbarPlaceholder == NO)
+                    textField.iq_shouldHideToolbarPlaceholder == NO)
                 {
                     //Updating placeholder     //(Bug ID: #148, #272)
                     if (toolbar.titleBarButton.title == nil ||
-                        [toolbar.titleBarButton.title isEqualToString:textField.drawingToolbarPlaceholder] == NO)
+                        [toolbar.titleBarButton.title isEqualToString:textField.iq_drawingToolbarPlaceholder] == NO)
                     {
-                        [toolbar.titleBarButton setTitle:textField.drawingToolbarPlaceholder];
+                        [toolbar.titleBarButton setTitle:textField.iq_drawingToolbarPlaceholder];
                     }
                     
                     //Setting toolbar title font.   //  (Enhancement ID: #30)
@@ -1839,25 +1839,25 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             {
                 if (siblings.count == 1)
                 {
-                    textField.keyboardToolbar.previousBarButton.enabled = NO;
-                    textField.keyboardToolbar.nextBarButton.enabled = NO;
+                    textField.iq_keyboardToolbar.previousBarButton.enabled = NO;
+                    textField.iq_keyboardToolbar.nextBarButton.enabled = NO;
                 }
                 else
                 {
-                    textField.keyboardToolbar.previousBarButton.enabled = NO;
-                    textField.keyboardToolbar.nextBarButton.enabled = YES;
+                    textField.iq_keyboardToolbar.previousBarButton.enabled = NO;
+                    textField.iq_keyboardToolbar.nextBarButton.enabled = YES;
                 }
             }
             //    If lastTextField then next should not be enaled.
             else if ([siblings lastObject] == textField)
             {
-                textField.keyboardToolbar.previousBarButton.enabled = YES;
-                textField.keyboardToolbar.nextBarButton.enabled = NO;
+                textField.iq_keyboardToolbar.previousBarButton.enabled = YES;
+                textField.iq_keyboardToolbar.nextBarButton.enabled = NO;
             }
             else
             {
-                textField.keyboardToolbar.previousBarButton.enabled = YES;
-                textField.keyboardToolbar.nextBarButton.enabled = YES;
+                textField.iq_keyboardToolbar.previousBarButton.enabled = YES;
+                textField.iq_keyboardToolbar.nextBarButton.enabled = YES;
             }
         }
     }
@@ -1929,11 +1929,11 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 
         //Handling search bar special case
         {
-            UISearchBar *searchBar = currentTextFieldView.searchBar;
+            UISearchBar *searchBar = currentTextFieldView.iq_searchBar;
             
             if (searchBar)
             {
-                invocation = searchBar.keyboardToolbar.previousBarButton.invocation;
+                invocation = searchBar.iq_keyboardToolbar.previousBarButton.invocation;
             }
         }
 
@@ -1967,11 +1967,11 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 
         //Handling search bar special case
         {
-            UISearchBar *searchBar = currentTextFieldView.searchBar;
+            UISearchBar *searchBar = currentTextFieldView.iq_searchBar;
             
             if (searchBar)
             {
-                invocation = searchBar.keyboardToolbar.nextBarButton.invocation;
+                invocation = searchBar.iq_keyboardToolbar.nextBarButton.invocation;
             }
         }
 
@@ -2003,11 +2003,11 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 
     //Handling search bar special case
     {
-        UISearchBar *searchBar = currentTextFieldView.searchBar;
+        UISearchBar *searchBar = currentTextFieldView.iq_searchBar;
         
         if (searchBar)
         {
-            invocation = searchBar.keyboardToolbar.doneBarButton.invocation;
+            invocation = searchBar.iq_keyboardToolbar.doneBarButton.invocation;
         }
     }
 

--- a/IQKeyboardManager/IQKeyboardReturnKeyHandler.m
+++ b/IQKeyboardManager/IQKeyboardReturnKeyHandler.m
@@ -107,14 +107,14 @@
 #pragma mark - Add/Remove TextFields
 -(void)addResponderFromView:(UIView*)view
 {
-    NSArray<UIView*> *textFields = [view deepResponderViews];
+    NSArray<UIView*> *textFields = [view iq_deepResponderViews];
     
     for (UIView *textField in textFields)  [self addTextFieldView:textField];
 }
 
 -(void)removeResponderFromView:(UIView*)view
 {
-    NSArray<UIView*> *textFields = [view deepResponderViews];
+    NSArray<UIView*> *textFields = [view iq_deepResponderViews];
     
     for (UIView *textField in textFields)  [self removeTextFieldView:textField];
 }
@@ -171,7 +171,7 @@
     //If find any consider responderView in it's upper hierarchy then will get deepResponderView. (Bug ID: #347)
     for (Class consideredClass in [[IQKeyboardManager sharedManager] toolbarPreviousNextAllowedClasses])
     {
-        superConsideredView = [textField superviewOfClassType:consideredClass];
+        superConsideredView = [textField iq_superviewOfClassType:consideredClass];
         
         if (superConsideredView)
             break;
@@ -182,24 +182,24 @@
     //If there is a tableView in view's hierarchy, then fetching all it's subview that responds. No sorting for tableView, it's by subView position.
     if (superConsideredView)  //     //   (Enhancement ID: #22)
     {
-        textFields = [superConsideredView deepResponderViews];
+        textFields = [superConsideredView iq_deepResponderViews];
     }
     //Otherwise fetching all the siblings
     else
     {
-        textFields = [textField responderSiblings];
+        textFields = [textField iq_responderSiblings];
         
         //Sorting textFields according to behaviour
         switch ([[IQKeyboardManager sharedManager] toolbarManageBehaviour])
         {
                 //If needs to sort it by tag
             case IQAutoToolbarByTag:
-                textFields = [textFields sortedArrayByTag];
+                textFields = [textFields iq_sortedArrayByTag];
                 break;
                 
                 //If needs to sort it by Position
             case IQAutoToolbarByPosition:
-                textFields = [textFields sortedArrayByPosition];
+                textFields = [textFields iq_sortedArrayByPosition];
                 break;
                 
             default:
@@ -220,7 +220,7 @@
     //If find any consider responderView in it's upper hierarchy then will get deepResponderView. (Bug ID: #347)
     for (Class consideredClass in [[IQKeyboardManager sharedManager] toolbarPreviousNextAllowedClasses])
     {
-        superConsideredView = [textField superviewOfClassType:consideredClass];
+        superConsideredView = [textField iq_superviewOfClassType:consideredClass];
         
         if (superConsideredView)
             break;
@@ -231,24 +231,24 @@
     //If there is a tableView in view's hierarchy, then fetching all it's subview that responds. No sorting for tableView, it's by subView position.
     if (superConsideredView)  //     //   (Enhancement ID: #22)
     {
-        textFields = [superConsideredView deepResponderViews];
+        textFields = [superConsideredView iq_deepResponderViews];
     }
     //Otherwise fetching all the siblings
     else
     {
-        textFields = [textField responderSiblings];
+        textFields = [textField iq_responderSiblings];
         
         //Sorting textFields according to behaviour
         switch ([[IQKeyboardManager sharedManager] toolbarManageBehaviour])
         {
                 //If needs to sort it by tag
             case IQAutoToolbarByTag:
-                textFields = [textFields sortedArrayByTag];
+                textFields = [textFields iq_sortedArrayByTag];
                 break;
                 
                 //If needs to sort it by Position
             case IQAutoToolbarByPosition:
-                textFields = [textFields sortedArrayByPosition];
+                textFields = [textFields iq_sortedArrayByPosition];
                 break;
                 
             default:

--- a/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h
+++ b/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h
@@ -41,13 +41,13 @@
 
 @interface UIImage (IQKeyboardToolbarNextPreviousImage)
 
-+(UIImage*)keyboardPreviousiOS9Image;
-+(UIImage*)keyboardNextiOS9Image;
-+(UIImage*)keyboardPreviousiOS10Image;
-+(UIImage*)keyboardNextiOS10Image;
++(UIImage*)iq_keyboardPreviousiOS9Image;
++(UIImage*)iq_keyboardNextiOS9Image;
++(UIImage*)iq_keyboardPreviousiOS10Image;
++(UIImage*)iq_keyboardNextiOS10Image;
 
-+(UIImage*)keyboardPreviousImage;
-+(UIImage*)keyboardNextImage;
++(UIImage*)iq_keyboardPreviousImage;
++(UIImage*)iq_keyboardNextImage;
 
 @end
 
@@ -63,87 +63,84 @@
 /**
  IQToolbar references for better customization control.
  */
-@property (readonly, nonatomic, nonnull) IQToolbar *keyboardToolbar;
+@property (readonly, nonatomic, nonnull) IQToolbar *iq_keyboardToolbar;
 
 /**
  If `shouldHideToolbarPlaceholder` is YES, then title will not be added to the toolbar. Default to NO.
  */
-@property (assign, nonatomic) BOOL shouldHideToolbarPlaceholder;
-@property (assign, nonatomic) BOOL shouldHidePlaceholderText __attribute__((deprecated("This is renamed to `shouldHideToolbarPlaceholder` for more clear naming.")));
+@property (assign, nonatomic) BOOL iq_shouldHideToolbarPlaceholder;
 
 /**
  `toolbarPlaceholder` to override default `placeholder` text when drawing text on toolbar.
  */
-@property (nullable, strong, nonatomic) NSString* toolbarPlaceholder;
-@property (nullable, strong, nonatomic) NSString* placeholderText __attribute__((deprecated("This is renamed to `toolbarPlaceholder` for more clear naming.")));
+@property (nullable, strong, nonatomic) NSString* iq_toolbarPlaceholder;
 
 /**
- `drawingToolbarPlaceholder` will be actual text used to draw on toolbar. This would either `placeholder` or `toolbarPlaceholder`.
+ `drawingToolbarPlaceholder` will be actual text used to draw on toolbar.
  */
-@property (nullable, strong, nonatomic, readonly) NSString* drawingToolbarPlaceholder;
-@property (nullable, strong, nonatomic, readonly) NSString* drawingPlaceholderText __attribute__((deprecated("This is renamed to `drawingToolbarPlaceholder` for more clear naming.")));
+@property (nullable, strong, nonatomic, readonly) NSString* iq_drawingToolbarPlaceholder;
 
 ///-------------
 /// MARK: Common
 ///-------------
 
-- (void)addKeyboardToolbarWithTarget:(nullable id)target titleText:(nullable NSString*)titleText rightBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)rightBarButtonConfiguration previousBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)previousBarButtonConfiguration nextBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)nextBarButtonConfiguration;
+- (void)iq_addKeyboardToolbarWithTarget:(nullable id)target titleText:(nullable NSString*)titleText rightBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)rightBarButtonConfiguration previousBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)previousBarButtonConfiguration nextBarButtonConfiguration:(nullable IQBarButtonItemConfiguration*)nextBarButtonConfiguration;
 
 ///------------
 /// @name Done
 ///------------
 
-- (void)addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action;
-- (void)addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
+- (void)iq_addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action;
+- (void)iq_addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addDoneOnKeyboardWithTarget:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
 
 ///------------
 /// @name Right
 ///------------
 
-- (void)addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action;
-- (void)addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
+- (void)iq_addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action;
+- (void)iq_addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addRightButtonOnKeyboardWithText:(nullable NSString*)text target:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
 
-- (void)addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action;
-- (void)addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
+- (void)iq_addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action;
+- (void)iq_addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addRightButtonOnKeyboardWithImage:(nullable UIImage*)image target:(nullable id)target action:(nullable SEL)action titleText:(nullable NSString*)titleText;
 
 ///------------------
 /// @name Cancel/Done
 ///------------------
 
-- (void)addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction;
-- (void)addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction titleText:(nullable NSString*)titleText;
+- (void)iq_addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction;
+- (void)iq_addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addCancelDoneOnKeyboardWithTarget:(nullable id)target cancelAction:(nullable SEL)cancelAction doneAction:(nullable SEL)doneAction titleText:(nullable NSString*)titleText;
 
 ///-----------------
 /// @name Right/Left
 ///-----------------
 
-- (void)addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction;
-- (void)addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
+- (void)iq_addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction;
+- (void)iq_addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addLeftRightOnKeyboardWithTarget:(nullable id)target leftButtonTitle:(nullable NSString*)leftButtonTitle rightButtonTitle:(nullable NSString*)rightButtonTitle leftButtonAction:(nullable SEL)leftButtonAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
 
 ///-------------------------
 /// @name Previous/Next/Done
 ///-------------------------
 
-- (void)addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction;
-- (void)addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction titleText:(nullable NSString*)titleText;
+- (void)iq_addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction;
+- (void)iq_addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addPreviousNextDoneOnKeyboardWithTarget:(nullable id)target previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction doneAction:(nullable SEL)doneAction titleText:(nullable NSString*)titleText;
 
 ///--------------------------
 /// @name Previous/Next/Right
 ///--------------------------
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction;
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonTitle:(nullable NSString*)rightButtonTitle previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction;
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder;
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction titleText:(nullable NSString*)titleText;
 
 @end
 

--- a/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
+++ b/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
@@ -68,7 +68,7 @@
 
 @implementation UIImage (IQKeyboardToolbarNextPreviousImage)
 
-+(UIImage*)keyboardPreviousiOS9Image
++(UIImage*)iq_keyboardPreviousiOS9Image
 {
     static UIImage *keyboardPreviousiOS9Image = nil;
     
@@ -102,7 +102,7 @@
     return keyboardPreviousiOS9Image;
 }
 
-+(UIImage*)keyboardNextiOS9Image
++(UIImage*)iq_keyboardNextiOS9Image
 {
     static UIImage *keyboardNextiOS9Image = nil;
     
@@ -136,7 +136,7 @@
     return keyboardNextiOS9Image;
 }
 
-+(UIImage*)keyboardPreviousiOS10Image
++(UIImage*)iq_keyboardPreviousiOS10Image
 {
     static UIImage *keyboardPreviousiOS10Image = nil;
     
@@ -170,7 +170,7 @@
     return keyboardPreviousiOS10Image;
 }
 
-+(UIImage*)keyboardNextiOS10Image
++(UIImage*)iq_keyboardNextiOS10Image
 {
     static UIImage *keyboardNextiOS10Image = nil;
     
@@ -204,7 +204,7 @@
     return keyboardNextiOS10Image;
 }
 
-+(UIImage*)keyboardPreviousImage
++(UIImage*)iq_keyboardPreviousImage
 {
 #ifdef __IPHONE_11_0
     if (@available(iOS 10.0, *))
@@ -212,15 +212,15 @@
     if (IQ_IS_IOS10_OR_GREATER)
 #endif
     {
-        return [UIImage keyboardPreviousiOS10Image];
+        return [UIImage iq_keyboardPreviousiOS10Image];
     }
     else
     {
-        return [UIImage keyboardPreviousiOS9Image];
+        return [UIImage iq_keyboardPreviousiOS9Image];
     }
 }
 
-+(UIImage*)keyboardNextImage
++(UIImage*)iq_keyboardNextImage
 {
 #ifdef __IPHONE_11_0
     if (@available(iOS 10.0, *))
@@ -228,11 +228,11 @@
     if (IQ_IS_IOS10_OR_GREATER)
 #endif
     {
-        return [UIImage keyboardNextiOS10Image];
+        return [UIImage iq_keyboardNextiOS10Image];
     }
     else
     {
-        return [UIImage keyboardNextiOS9Image];
+        return [UIImage iq_keyboardNextiOS9Image];
     }
 }
 
@@ -242,7 +242,7 @@
 /*UIKeyboardToolbar Category implementation*/
 @implementation UIView (IQToolbarAddition)
 
--(IQToolbar *)keyboardToolbar
+-(IQToolbar *)iq_keyboardToolbar
 {
     IQToolbar *keyboardToolbar = nil;
     if ([[self inputAccessoryView] isKindOfClass:[IQToolbar class]])
@@ -251,74 +251,54 @@
     }
     else
     {
-        keyboardToolbar = objc_getAssociatedObject(self, @selector(keyboardToolbar));
+        keyboardToolbar = objc_getAssociatedObject(self, @selector(iq_keyboardToolbar));
         
         if (keyboardToolbar == nil)
         {
             keyboardToolbar = [[IQToolbar alloc] init];
             
-            objc_setAssociatedObject(self, @selector(keyboardToolbar), keyboardToolbar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(self, @selector(iq_keyboardToolbar), keyboardToolbar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
     }
     
     return keyboardToolbar;
 }
 
--(void)setShouldHideToolbarPlaceholder:(BOOL)shouldHideToolbarPlaceholder
+-(void)setIq_shouldHideToolbarPlaceholder:(BOOL)shouldHideToolbarPlaceholder
 {
-    objc_setAssociatedObject(self, @selector(shouldHideToolbarPlaceholder), @(shouldHideToolbarPlaceholder), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(iq_shouldHideToolbarPlaceholder), @(shouldHideToolbarPlaceholder), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    self.keyboardToolbar.titleBarButton.title = self.drawingToolbarPlaceholder;
+    self.iq_keyboardToolbar.titleBarButton.title = self.iq_drawingToolbarPlaceholder;
 }
 
--(BOOL)shouldHideToolbarPlaceholder
+-(BOOL)iq_shouldHideToolbarPlaceholder
 {
-    NSNumber *shouldHideToolbarPlaceholder = objc_getAssociatedObject(self, @selector(shouldHideToolbarPlaceholder));
+    NSNumber *shouldHideToolbarPlaceholder = objc_getAssociatedObject(self, @selector(iq_shouldHideToolbarPlaceholder));
     return [shouldHideToolbarPlaceholder boolValue];
 }
 
--(void)setShouldHidePlaceholderText:(BOOL)shouldHidePlaceholderText
+-(void)setIq_toolbarPlaceholder:(NSString *)toolbarPlaceholder
 {
-    [self setShouldHideToolbarPlaceholder:shouldHidePlaceholderText];
+    objc_setAssociatedObject(self, @selector(iq_toolbarPlaceholder), toolbarPlaceholder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    self.iq_keyboardToolbar.titleBarButton.title = self.iq_drawingToolbarPlaceholder;
 }
 
--(BOOL)shouldHidePlaceholderText
+-(NSString *)iq_toolbarPlaceholder
 {
-    return [self shouldHideToolbarPlaceholder];
-}
-
--(void)setToolbarPlaceholder:(NSString *)toolbarPlaceholder
-{
-    objc_setAssociatedObject(self, @selector(toolbarPlaceholder), toolbarPlaceholder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
-    self.keyboardToolbar.titleBarButton.title = self.drawingToolbarPlaceholder;
-}
-
--(NSString *)toolbarPlaceholder
-{
-    NSString *toolbarPlaceholder = objc_getAssociatedObject(self, @selector(toolbarPlaceholder));
+    NSString *toolbarPlaceholder = objc_getAssociatedObject(self, @selector(iq_toolbarPlaceholder));
     return toolbarPlaceholder;
 }
 
--(void)setPlaceholderText:(NSString*)placeholderText
+-(NSString *)iq_drawingToolbarPlaceholder
 {
-    [self setToolbarPlaceholder:placeholderText];
-}
-
--(NSString*)placeholderText
-{
-    return [self toolbarPlaceholder];
-}
-
--(NSString *)drawingToolbarPlaceholder
-{
-    if (self.shouldHideToolbarPlaceholder)
+    if (self.iq_shouldHideToolbarPlaceholder)
     {
         return nil;
     }
-    else if (self.toolbarPlaceholder.length != 0)
+    else if (self.iq_toolbarPlaceholder.length != 0)
     {
-        return self.toolbarPlaceholder;
+        return self.iq_toolbarPlaceholder;
     }
     else if ([self respondsToSelector:@selector(placeholder)])
     {
@@ -328,11 +308,6 @@
     {
         return nil;
     }
-}
-
--(NSString*)drawingPlaceholderText
-{
-    return [self drawingToolbarPlaceholder];
 }
 
 #pragma mark - Private helper
@@ -351,13 +326,13 @@
 
 #pragma mark - Common
 
-- (void)addKeyboardToolbarWithTarget:(id)target titleText:(NSString*)titleText rightBarButtonConfiguration:(IQBarButtonItemConfiguration*)rightBarButtonConfiguration previousBarButtonConfiguration:(IQBarButtonItemConfiguration*)previousBarButtonConfiguration nextBarButtonConfiguration:(IQBarButtonItemConfiguration*)nextBarButtonConfiguration
+- (void)iq_addKeyboardToolbarWithTarget:(id)target titleText:(NSString*)titleText rightBarButtonConfiguration:(IQBarButtonItemConfiguration*)rightBarButtonConfiguration previousBarButtonConfiguration:(IQBarButtonItemConfiguration*)previousBarButtonConfiguration nextBarButtonConfiguration:(IQBarButtonItemConfiguration*)nextBarButtonConfiguration
 {
     //If can't set InputAccessoryView. Then return
     if (![self respondsToSelector:@selector(setInputAccessoryView:)])    return;
     
     //  Creating a toolBar for phoneNumber keyboard
-    IQToolbar *toolbar = self.keyboardToolbar;
+    IQToolbar *toolbar = self.iq_keyboardToolbar;
     
     NSMutableArray<UIBarButtonItem*> *items = [[NSMutableArray alloc] init];
     
@@ -513,163 +488,163 @@
 
 #pragma mark - Right
 
-- (void)addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action
+- (void)iq_addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action
 {
-    [self addRightButtonOnKeyboardWithText:text target:target action:action titleText:nil];
+    [self iq_addRightButtonOnKeyboardWithText:text target:target action:action titleText:nil];
 }
 
-- (void)addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+- (void)iq_addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addRightButtonOnKeyboardWithText:text target:target action:action titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addRightButtonOnKeyboardWithText:text target:target action:action titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action titleText:(NSString*)titleText
+- (void)iq_addRightButtonOnKeyboardWithText:(NSString*)text target:(id)target action:(SEL)action titleText:(NSString*)titleText
 {
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithTitle:text action:action];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
 }
 
 
-- (void)addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action
+- (void)iq_addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action
 {
-    [self addRightButtonOnKeyboardWithImage:image target:target action:action titleText:nil];
+    [self iq_addRightButtonOnKeyboardWithImage:image target:target action:action titleText:nil];
 }
 
-- (void)addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+- (void)iq_addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addRightButtonOnKeyboardWithImage:image target:target action:action titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addRightButtonOnKeyboardWithImage:image target:target action:action titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action titleText:(NSString*)titleText
+- (void)iq_addRightButtonOnKeyboardWithImage:(UIImage*)image target:(id)target action:(SEL)action titleText:(NSString*)titleText
 {
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:image action:action];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
 }
 
 
--(void)addDoneOnKeyboardWithTarget:(id)target action:(SEL)action
+-(void)iq_addDoneOnKeyboardWithTarget:(id)target action:(SEL)action
 {
-    [self addDoneOnKeyboardWithTarget:target action:action titleText:nil];
+    [self iq_addDoneOnKeyboardWithTarget:target action:action titleText:nil];
 }
 
--(void)addDoneOnKeyboardWithTarget:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+-(void)iq_addDoneOnKeyboardWithTarget:(id)target action:(SEL)action shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addDoneOnKeyboardWithTarget:target action:action titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addDoneOnKeyboardWithTarget:target action:action titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addDoneOnKeyboardWithTarget:(id)target action:(SEL)action titleText:(NSString*)titleText
+- (void)iq_addDoneOnKeyboardWithTarget:(id)target action:(SEL)action titleText:(NSString*)titleText
 {
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone action:action];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:nil nextBarButtonConfiguration:nil];
 }
 
 
-- (void)addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction
+- (void)iq_addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction
 {
-    [self addLeftRightOnKeyboardWithTarget:target leftButtonTitle:leftTitle rightButtonTitle:rightTitle leftButtonAction:leftAction rightButtonAction:rightAction titleText:nil];
+    [self iq_addLeftRightOnKeyboardWithTarget:target leftButtonTitle:leftTitle rightButtonTitle:rightTitle leftButtonAction:leftAction rightButtonAction:rightAction titleText:nil];
 }
 
-- (void)addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+- (void)iq_addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addLeftRightOnKeyboardWithTarget:target leftButtonTitle:leftTitle rightButtonTitle:rightTitle leftButtonAction:leftAction rightButtonAction:rightAction titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addLeftRightOnKeyboardWithTarget:target leftButtonTitle:leftTitle rightButtonTitle:rightTitle leftButtonAction:leftAction rightButtonAction:rightAction titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction titleText:(NSString*)titleText
+- (void)iq_addLeftRightOnKeyboardWithTarget:(id)target leftButtonTitle:(NSString*)leftTitle rightButtonTitle:(NSString*)rightTitle leftButtonAction:(SEL)leftAction rightButtonAction:(SEL)rightAction titleText:(NSString*)titleText
 {
     IQBarButtonItemConfiguration *leftConfiguration = [[IQBarButtonItemConfiguration alloc] initWithTitle:leftTitle action:leftAction];
     
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithTitle:rightTitle action:rightAction];
 
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:leftConfiguration nextBarButtonConfiguration:nil];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:leftConfiguration nextBarButtonConfiguration:nil];
 }
 
 
--(void)addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction
+-(void)iq_addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction
 {
-    [self addCancelDoneOnKeyboardWithTarget:target cancelAction:cancelAction doneAction:doneAction titleText:nil];
+    [self iq_addCancelDoneOnKeyboardWithTarget:target cancelAction:cancelAction doneAction:doneAction titleText:nil];
 }
 
--(void)addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+-(void)iq_addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addCancelDoneOnKeyboardWithTarget:target cancelAction:cancelAction doneAction:doneAction titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addCancelDoneOnKeyboardWithTarget:target cancelAction:cancelAction doneAction:doneAction titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction titleText:(NSString*)titleText
+- (void)iq_addCancelDoneOnKeyboardWithTarget:(id)target cancelAction:(SEL)cancelAction doneAction:(SEL)doneAction titleText:(NSString*)titleText
 {
     IQBarButtonItemConfiguration *leftConfiguration = [[IQBarButtonItemConfiguration alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel action:cancelAction];
     
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone action:doneAction];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:leftConfiguration nextBarButtonConfiguration:nil];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:leftConfiguration nextBarButtonConfiguration:nil];
 }
 
 
--(void)addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction
+-(void)iq_addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction
 {
-    [self addPreviousNextDoneOnKeyboardWithTarget:target previousAction:previousAction nextAction:nextAction doneAction:doneAction titleText:nil];
+    [self iq_addPreviousNextDoneOnKeyboardWithTarget:target previousAction:previousAction nextAction:nextAction doneAction:doneAction titleText:nil];
 }
 
--(void)addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+-(void)iq_addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addPreviousNextDoneOnKeyboardWithTarget:target previousAction:previousAction nextAction:nextAction doneAction:doneAction titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addPreviousNextDoneOnKeyboardWithTarget:target previousAction:previousAction nextAction:nextAction doneAction:doneAction titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction titleText:(NSString*)titleText
+- (void)iq_addPreviousNextDoneOnKeyboardWithTarget:(id)target previousAction:(SEL)previousAction nextAction:(SEL)nextAction doneAction:(SEL)doneAction titleText:(NSString*)titleText
 {
-    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardPreviousImage] action:previousAction];
+    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardPreviousImage] action:previousAction];
     
-    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardNextImage] action:nextAction];
+    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardNextImage] action:nextAction];
     
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone action:doneAction];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
 }
 
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction
 {
-    [self addPreviousNextRightOnKeyboardWithTarget:target rightButtonImage:rightButtonImage previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:nil];
+    [self iq_addPreviousNextRightOnKeyboardWithTarget:target rightButtonImage:rightButtonImage previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:nil];
 }
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(nullable id)target rightButtonImage:(nullable UIImage*)rightButtonImage previousAction:(nullable SEL)previousAction nextAction:(nullable SEL)nextAction rightButtonAction:(nullable SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addPreviousNextRightOnKeyboardWithTarget:target rightButtonImage:rightButtonImage previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addPreviousNextRightOnKeyboardWithTarget:target rightButtonImage:rightButtonImage previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonImage:(UIImage*)rightButtonImage previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction titleText:(NSString*)titleText
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonImage:(UIImage*)rightButtonImage previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction titleText:(NSString*)titleText
 {
-    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardPreviousImage] action:previousAction];
+    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardPreviousImage] action:previousAction];
     
-    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardNextImage] action:nextAction];
+    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardNextImage] action:nextAction];
     
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:rightButtonImage action:rightButtonAction];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
 }
 
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction
 {
-    [self addPreviousNextRightOnKeyboardWithTarget:target rightButtonTitle:rightButtonTitle previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:nil];
+    [self iq_addPreviousNextRightOnKeyboardWithTarget:target rightButtonTitle:rightButtonTitle previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:nil];
 }
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction shouldShowPlaceholder:(BOOL)shouldShowPlaceholder
 {
-    [self addPreviousNextRightOnKeyboardWithTarget:target rightButtonTitle:rightButtonTitle previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:(shouldShowPlaceholder?[self drawingToolbarPlaceholder]:nil)];
+    [self iq_addPreviousNextRightOnKeyboardWithTarget:target rightButtonTitle:rightButtonTitle previousAction:previousAction nextAction:nextAction rightButtonAction:rightButtonAction titleText:(shouldShowPlaceholder?[self iq_drawingToolbarPlaceholder]:nil)];
 }
 
-- (void)addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction titleText:(NSString*)titleText
+- (void)iq_addPreviousNextRightOnKeyboardWithTarget:(id)target rightButtonTitle:(NSString*)rightButtonTitle previousAction:(SEL)previousAction nextAction:(SEL)nextAction rightButtonAction:(SEL)rightButtonAction titleText:(NSString*)titleText
 {
-    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardPreviousImage] action:previousAction];
+    IQBarButtonItemConfiguration *previousConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardPreviousImage] action:previousAction];
     
-    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardNextImage] action:nextAction];
+    IQBarButtonItemConfiguration *nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage iq_keyboardNextImage] action:nextAction];
     
     IQBarButtonItemConfiguration *rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithTitle:rightButtonTitle action:rightButtonAction];
     
-    [self addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
+    [self iq_addKeyboardToolbarWithTarget:target titleText:titleText rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:previousConfiguration nextBarButtonConfiguration:nextConfiguration];
 }
 
 


### PR DESCRIPTION
# Description

Add "iq_" prefix to every methods and properties extension of system class (UIKit and Foundation).
- Avoid name clash with user subclasses. Ex: currently, users can't have a subclass of UIView if you use IQKeyboardManager
- It follow the guidelines for class extensions described here: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW4

- Property names with 'IQ' are left unchanged (IQLayoutGuideConstraint)
- Deprecated methods have been removed

Since the modifications are part of the public interface, this is breaking change and the demo project has been updated.

The change only target the objc library but the swift part (@objc public) is also subject to this issue.

Fixes #1429 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update