### PR TITLE
Added support to disable content inset adjustment on keyboard apparition

### DIFF
--- a/IQKeyboardManager/Categories/IQUIScrollView+Additions.h
+++ b/IQKeyboardManager/Categories/IQUIScrollView+Additions.h
@@ -33,6 +33,11 @@
 @property(nonatomic, assign) BOOL shouldIgnoreScrollingAdjustment;
 
 /**
+ If YES, then scrollview will ignore content inset adjustment (simply not updating it) when keyboard is shown. Default is NO.
+ */
+@property(nonatomic, assign) BOOL shouldIgnoreContentInsetAdjustment;
+
+/**
  Restore scrollViewContentOffset when resigning from scrollView. Default is NO.
  */
 @property(nonatomic, assign) BOOL shouldRestoreScrollViewContentOffset;

--- a/IQKeyboardManager/Categories/IQUIScrollView+Additions.m
+++ b/IQKeyboardManager/Categories/IQUIScrollView+Additions.m
@@ -38,6 +38,18 @@
     return [shouldIgnoreScrollingAdjustment boolValue];
 }
 
+-(void)setShouldIgnoreContentInsetAdjustment:(BOOL)shouldIgnoreContentInsetAdjustment
+{
+    objc_setAssociatedObject(self, @selector(shouldIgnoreContentInsetAdjustment), @(shouldIgnoreContentInsetAdjustment), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+-(BOOL)shouldIgnoreContentInsetAdjustment
+{
+    NSNumber *shouldIgnoreContentInsetAdjustment = objc_getAssociatedObject(self, @selector(shouldIgnoreContentInsetAdjustment));
+    
+    return [shouldIgnoreContentInsetAdjustment boolValue];
+}
+
 -(void)setShouldRestoreScrollViewContentOffset:(BOOL)shouldRestoreScrollViewContentOffset
 {
     objc_setAssociatedObject(self, @selector(shouldRestoreScrollViewContentOffset), @(shouldRestoreScrollViewContentOffset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -49,6 +49,7 @@
 #import <UIKit/UINavigationController.h>
 #import <UIKit/UITouch.h>
 #import <UIKit/UIWindow.h>
+#import <UIKit/UIStackView.h>
 #import <UIKit/NSLayoutConstraint.h>
 
 NSInteger const kIQDoneButtonToolbarTag             =   -1002;
@@ -977,6 +978,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             }
             
             //Updating contentInset
+            if (strongLastScrollView.shouldIgnoreContentInsetAdjustment == false)
             {
                 CGRect lastScrollViewRect = [[strongLastScrollView superview] convertRect:strongLastScrollView.frame toView:keyWindow];
 

--- a/IQKeyboardManagerSwift/Categories/IQUIScrollView+Additions.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUIScrollView+Additions.swift
@@ -25,6 +25,7 @@ import Foundation
 import UIKit
 
 private var kIQShouldIgnoreScrollingAdjustment      = "kIQShouldIgnoreScrollingAdjustment"
+private var kIQShouldIgnoreContentInsetAdjustment   = "kIQShouldIgnoreContentInsetAdjustment"
 private var kIQShouldRestoreScrollViewContentOffset = "kIQShouldRestoreScrollViewContentOffset"
 
 @objc public extension UIScrollView {
@@ -46,6 +47,23 @@ private var kIQShouldRestoreScrollViewContentOffset = "kIQShouldRestoreScrollVie
         }
     }
 
+    /**
+     If YES, then scrollview will ignore content inset adjustment (simply not updating it) when keyboard is shown. Default is NO.
+     */
+    @objc var shouldIgnoreContentInsetAdjustment: Bool {
+        get {
+            
+            if let aValue = objc_getAssociatedObject(self, &kIQShouldIgnoreContentInsetAdjustment) as? Bool {
+                return aValue
+            } else {
+                return false
+            }
+        }
+        set(newValue) {
+            objc_setAssociatedObject(self, &kIQShouldIgnoreContentInsetAdjustment, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
     /**
      To set customized distance from keyboard for textField/textView. Can't be less than zero
      */

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -1231,7 +1231,8 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
                 }
                 
                 //Updating contentInset
-                if let lastScrollViewRect = lastScrollView.superview?.convert(lastScrollView.frame, to: window) {
+                if let lastScrollViewRect = lastScrollView.superview?.convert(lastScrollView.frame, to: window),
+                    lastScrollView.shouldIgnoreContentInsetAdjustment == false {
                     
                     let bottom : CGFloat = (kbSize.height-newKeyboardDistanceFromTextField)-(window.frame.height-lastScrollViewRect.maxY)
                     


### PR DESCRIPTION
# Description

Unless I missed something, your library does not handle the case where the scroll view is pinned to a footer view which should go on top of the keyboard.
In this specific case, I need to handle the keyboard resizing manually and the best thing to do is deactivate IQKeyboardManagerSwift for touching contentInset since I'm touching somehow the frame at the same time (with an autolayout constraint for example)

Without the content of this PR, this is the issue (on 6.2.0, 6.3.0 seems to have improved the way it works)

Bug with 6.2.0
![CZitJ8h_d2l7CcccvihS3gEND5lb5ovxpTuQMQW35MXdgi4PDj-O1eSJc_bilmjCU4QZG7V5rTbL-QCXYiYjzhA1jQB_zmxltR5bgJ1-nls](https://user-images.githubusercontent.com/968830/57653782-abdb3d80-75a0-11e9-9d32-7229a4515593.gif)

I think it is a way of handling this situation https://github.com/hackiftekhar/IQKeyboardManager/wiki/IQKeyboardManager-6.0.0-Migration-Guide#known-issues

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
