### PR TITLE
[performance]Remove useless container

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -126,8 +126,6 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 
 /*******************************************/
 
-@property(nonatomic, strong, nonnull, readwrite) NSMutableSet<Class> *registeredClasses;
-
 @property(nonatomic, strong, nonnull, readwrite) NSMutableSet<Class> *disabledDistanceHandlingClasses;
 @property(nonatomic, strong, nonnull, readwrite) NSMutableSet<Class> *enabledDistanceHandlingClasses;
 
@@ -209,9 +207,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
         dispatch_once(&onceToken, ^{
             
             __strong __typeof__(self) strongSelf = weakSelf;
-
-            strongSelf.registeredClasses = [[NSMutableSet alloc] init];
-
+            
             [strongSelf registerAllNotifications];
 
             //Creating gesture for @shouldResignOnTouchOutside. (Enhancement ID: #14)
@@ -2284,8 +2280,6 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
   didBeginEditingNotificationName:(nonnull NSString *)didBeginEditingNotificationName
     didEndEditingNotificationName:(nonnull NSString *)didEndEditingNotificationName
 {
-    [_registeredClasses addObject:aClass];
-    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldViewDidBeginEditing:) name:didBeginEditingNotificationName object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textFieldViewDidEndEditing:) name:didEndEditingNotificationName object:nil];
 }
@@ -2297,8 +2291,6 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
     didBeginEditingNotificationName:(nonnull NSString *)didBeginEditingNotificationName
       didEndEditingNotificationName:(nonnull NSString *)didEndEditingNotificationName
 {
-    [_registeredClasses removeObject:aClass];
-    
     [[NSNotificationCenter defaultCenter] removeObserver:self name:didBeginEditingNotificationName object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:didEndEditingNotificationName object:nil];
 }

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -56,11 +56,6 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
     ///---------------------------
     
     /**
-     Registered classes list with library.
-     */
-    private var registeredClasses  = [UIView.Type]()
-    
-    /**
     Enable/disable managing distance between keyboard and textField. Default is YES(Enabled when class loads in `+(void)load` method).
     */
     @objc public var enable = false {
@@ -752,8 +747,6 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
     */
     
     @objc public func registerTextFieldViewClass(_ aClass: UIView.Type, didBeginEditingNotificationName: String, didEndEditingNotificationName: String) {
-        
-        registeredClasses.append(aClass)
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.textFieldViewDidBeginEditing(_:)), name: Notification.Name(rawValue: didBeginEditingNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.textFieldViewDidEndEditing(_:)), name: Notification.Name(rawValue: didEndEditingNotificationName), object: nil)
@@ -761,12 +754,6 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
     
     @objc public func unregisterTextFieldViewClass(_ aClass: UIView.Type, didBeginEditingNotificationName: String, didEndEditingNotificationName: String) {
         
-        if let index = registeredClasses.firstIndex(where: { element in
-            return element == aClass.self
-        }) {
-            registeredClasses.remove(at: index)
-        }
-
         NotificationCenter.default.removeObserver(self, name: Notification.Name(rawValue: didBeginEditingNotificationName), object: nil)
         NotificationCenter.default.removeObserver(self, name: Notification.Name(rawValue: didEndEditingNotificationName), object: nil)
     }


### PR DESCRIPTION
# Description

Thanks for this great work! 

I found there is useless for `registeredClasses` and not a public `property`, so should we remove it ?

[performance] Remove useless container

Best Regards
