### PR TITLE
Support build setting in configuration to disable `+ (void)load` method

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -191,12 +191,19 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
 
 #pragma mark - Initializing functions
 
-/** Override +load method to enable KeyboardManager when class loader load IQKeyboardManager. Enabling when app starts (No need to write any code) */
+/**
+ Override +load method to enable KeyboardManager when class loader load IQKeyboardManager. Enabling when app starts (No need to write any code)
+ 
+ @Note: If you want to disable `+ (void)load` method, you can add build setting in configurations. Like that:
+       `{ 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) IQ_KEYBOARD_MANAGER_LOAD_METHOD_DISABLE=1' }`
+ */
+#if !IQ_KEYBOARD_MANAGER_LOAD_METHOD_DISABLE
 +(void)load
 {
     //Enabling IQKeyboardManager. Loading asynchronous on main thread
     [self performSelectorOnMainThread:@selector(sharedManager) withObject:nil waitUntilDone:NO];
 }
+#endif
 
 /*  Singleton Object Initialization. */
 -(instancetype)init


### PR DESCRIPTION
# Description

 The `+ (void)load` method takes more time in main thread when app launch, It affects the startup of the program. I just want introduce this feature that can control in `GCC_PREPROCESSOR_DEFINITIONS` style. Adding a **MACRO** to support  disable `+ (void)load` method in build setting configurations. 

Aim to  [https://github.com/hackiftekhar/IQKeyboardManager/issues/1428](https://github.com/hackiftekhar/IQKeyboardManager/issues/1428)

Note: non-breaking change which adds functionality

Using Cocoapods like that:
```ruby
post_install do |installer|
  installer.pods_project.targets.each do |target|
    if target.name == 'IQKeyboardManager'
      target.build_configurations.each do |config|
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'IQ_KEYBOARD_MANAGER_LOAD_METHOD_DISABLE=1'
      end
    end
   end
end
```

## Type of change

 * [x] New feature (non-breaking change which adds functionality)
