### PR TITLE
Fix constraint violations on IQToolbar.swift

### DIFF
--- a/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
@@ -145,8 +145,12 @@ open class IQToolbar: UIToolbar, UIInputViewAudioFeedback {
 
     override init(frame: CGRect) {
         _ = IQToolbar._classInitialize
-        super.init(frame: frame)
-        
+        if frame.width <= 10 {
+            super.init(frame: CGRect(x: 0, y: 0, width: 1000, height: 44))
+        } else {
+            super.init(frame: frame)
+        }
+
         sizeToFit()
         
         autoresizingMask = .flexibleWidth

--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -237,7 +237,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
             
         } else {
             
-            let newToolbar = IQToolbar()
+            let newToolbar = IQToolbar(frame: frame)
             
             objc_setAssociatedObject(self, &kIQKeyboardToolbar, newToolbar, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             


### PR DESCRIPTION
# Description

This commit resolves the broken constraint violations referenced in #1592 - motivation was a desire to clean up log output.

The constraint warnings were caused by initializing the IQToolbar with a frame of zero. The initializer will now default to a 1000 width frame if it detects a width of <= 10. This is not the cleanest fix, but it appears to solve the issue without any ill effects.

Fixes #1592 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
