### PR TITLE
[i18n] Add localization support for AccessibilityLabel in BarButtonItems

### DIFF
--- a/IQKeyboardManager/IQKeyboardManager.h
+++ b/IQKeyboardManager/IQKeyboardManager.h
@@ -153,8 +153,11 @@ extern NSInteger const kIQPreviousNextButtonToolbarTag;
  Toolbar previous/next/done button text, If nothing is provided then system default 'UIBarButtonSystemItemDone' will be used.
  */
 @property(nullable, nonatomic, strong) NSString *toolbarPreviousBarButtonItemText;
+@property(nullable, nonatomic, strong) NSString *toolbarPreviousBarButtonItemAccessibilityLabel;
 @property(nullable, nonatomic, strong) NSString *toolbarNextBarButtonItemText;
+@property(nullable, nonatomic, strong) NSString *toolbarNextBarButtonItemAccessibilityLabel;
 @property(nullable, nonatomic, strong) NSString *toolbarDoneBarButtonItemText;
+@property(nullable, nonatomic, strong) NSString *toolbarDoneBarButtonItemAccessibilityLabel;
 
 /**
  If YES, then it add the textField's placeholder text on IQToolbar. Default is YES.

--- a/IQKeyboardManager/IQKeyboardManager.m
+++ b/IQKeyboardManager/IQKeyboardManager.m
@@ -1997,6 +1997,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
             {
                 rightConfiguration = [[IQBarButtonItemConfiguration alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone action:@selector(doneAction:)];
             }
+            rightConfiguration.accessibilityLabel = _toolbarDoneBarButtonItemAccessibilityLabel ? : @"Done";
 
             //    If only one object is found, then adding only Done button.
             if ((siblings.count <= 1 && self.previousNextDisplayMode == IQPreviousNextDisplayModeDefault) || self.previousNextDisplayMode == IQPreviousNextDisplayModeAlwaysHide)
@@ -2024,6 +2025,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 {
                     prevConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardPreviousImage] action:@selector(previousAction:)];
                 }
+                prevConfiguration.accessibilityLabel = _toolbarPreviousBarButtonItemAccessibilityLabel ? : @"Previous";
                 
                 IQBarButtonItemConfiguration *nextConfiguration = nil;
                 
@@ -2041,6 +2043,7 @@ NSInteger const kIQPreviousNextButtonToolbarTag     =   -1005;
                 {
                     nextConfiguration = [[IQBarButtonItemConfiguration alloc] initWithImage:[UIImage keyboardNextImage] action:@selector(nextAction:)];
                 }
+                nextConfiguration.accessibilityLabel = _toolbarNextBarButtonItemAccessibilityLabel ? : @"Next";
 
                 [textField addKeyboardToolbarWithTarget:self titleText:(_shouldShowToolbarPlaceholder ? textField.drawingToolbarPlaceholder : nil) rightBarButtonConfiguration:rightConfiguration previousBarButtonConfiguration:prevConfiguration nextBarButtonConfiguration:nextConfiguration];
 

--- a/IQKeyboardManager/IQToolbar/IQToolbar.m
+++ b/IQKeyboardManager/IQToolbar/IQToolbar.m
@@ -90,7 +90,6 @@
     if (_previousBarButton == nil)
     {
         _previousBarButton = [[IQBarButtonItem alloc] initWithImage:nil style:UIBarButtonItemStylePlain target:nil action:nil];
-        _previousBarButton.accessibilityLabel = @"Previous";
     }
     
     return _previousBarButton;
@@ -101,7 +100,6 @@
     if (_nextBarButton == nil)
     {
         _nextBarButton = [[IQBarButtonItem alloc] initWithImage:nil style:UIBarButtonItemStylePlain target:nil action:nil];
-        _nextBarButton.accessibilityLabel = @"Next";
     }
     
     return _nextBarButton;
@@ -123,7 +121,6 @@
     if (_doneBarButton == nil)
     {
         _doneBarButton = [[IQBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:nil action:nil];
-        _doneBarButton.accessibilityLabel = @"Done";
     }
     
     return _doneBarButton;

--- a/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
+++ b/IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
@@ -322,6 +322,7 @@
         if (prev.isSystemItem == NO && (previousBarButtonConfiguration.image || previousBarButtonConfiguration.title))
         {
             prev.title = previousBarButtonConfiguration.title;
+            prev.accessibilityLabel = previousBarButtonConfiguration.accessibilityLabel;
             prev.image = previousBarButtonConfiguration.image;
             prev.target = target;
             prev.action = previousBarButtonConfiguration.action;
@@ -330,7 +331,7 @@
         {
             prev = [[IQBarButtonItem alloc] initWithImage:previousBarButtonConfiguration.image style:UIBarButtonItemStylePlain target:target action:previousBarButtonConfiguration.action];
             prev.invocation = toolbar.previousBarButton.invocation;
-            prev.accessibilityLabel = toolbar.previousBarButton.accessibilityLabel;
+            prev.accessibilityLabel = previousBarButtonConfiguration.accessibilityLabel;
             prev.enabled = toolbar.previousBarButton.enabled;
             prev.tag = toolbar.previousBarButton.tag;
             toolbar.previousBarButton = prev;
@@ -339,7 +340,7 @@
         {
             prev = [[IQBarButtonItem alloc] initWithTitle:previousBarButtonConfiguration.title style:UIBarButtonItemStylePlain target:target action:previousBarButtonConfiguration.action];
             prev.invocation = toolbar.previousBarButton.invocation;
-            prev.accessibilityLabel = toolbar.previousBarButton.accessibilityLabel;
+            prev.accessibilityLabel = previousBarButtonConfiguration.accessibilityLabel;
             prev.enabled = toolbar.previousBarButton.enabled;
             prev.tag = toolbar.previousBarButton.tag;
             toolbar.previousBarButton = prev;
@@ -348,7 +349,7 @@
         {
             prev = [[IQBarButtonItem alloc] initWithBarButtonSystemItem:previousBarButtonConfiguration.barButtonSystemItem target:target action:previousBarButtonConfiguration.action];
             prev.invocation = toolbar.previousBarButton.invocation;
-            prev.accessibilityLabel = toolbar.previousBarButton.accessibilityLabel;
+            prev.accessibilityLabel = previousBarButtonConfiguration.accessibilityLabel;
             prev.enabled = toolbar.previousBarButton.enabled;
             prev.tag = toolbar.previousBarButton.tag;
             toolbar.previousBarButton = prev;
@@ -369,6 +370,7 @@
         if (next.isSystemItem == NO && (nextBarButtonConfiguration.image || nextBarButtonConfiguration.title))
         {
             next.title = nextBarButtonConfiguration.title;
+            next.accessibilityLabel = nextBarButtonConfiguration.accessibilityLabel;
             next.image = nextBarButtonConfiguration.image;
             next.target = target;
             next.action = nextBarButtonConfiguration.action;
@@ -377,7 +379,7 @@
         {
             next = [[IQBarButtonItem alloc] initWithImage:nextBarButtonConfiguration.image style:UIBarButtonItemStylePlain target:target action:nextBarButtonConfiguration.action];
             next.invocation = toolbar.nextBarButton.invocation;
-            next.accessibilityLabel = toolbar.nextBarButton.accessibilityLabel;
+            next.accessibilityLabel = nextBarButtonConfiguration.accessibilityLabel;
             next.enabled = toolbar.nextBarButton.enabled;
             next.tag = toolbar.nextBarButton.tag;
             toolbar.nextBarButton = next;
@@ -386,7 +388,7 @@
         {
             next = [[IQBarButtonItem alloc] initWithTitle:nextBarButtonConfiguration.title style:UIBarButtonItemStylePlain target:target action:nextBarButtonConfiguration.action];
             next.invocation = toolbar.nextBarButton.invocation;
-            next.accessibilityLabel = toolbar.nextBarButton.accessibilityLabel;
+            next.accessibilityLabel = nextBarButtonConfiguration.accessibilityLabel;
             next.enabled = toolbar.nextBarButton.enabled;
             next.tag = toolbar.nextBarButton.tag;
             toolbar.nextBarButton = next;
@@ -395,7 +397,7 @@
         {
             next = [[IQBarButtonItem alloc] initWithBarButtonSystemItem:nextBarButtonConfiguration.barButtonSystemItem target:target action:nextBarButtonConfiguration.action];
             next.invocation = toolbar.nextBarButton.invocation;
-            next.accessibilityLabel = toolbar.nextBarButton.accessibilityLabel;
+            next.accessibilityLabel = nextBarButtonConfiguration.accessibilityLabel;
             next.enabled = toolbar.nextBarButton.enabled;
             next.tag = toolbar.nextBarButton.tag;
             toolbar.nextBarButton = next;
@@ -429,6 +431,7 @@
         if (done.isSystemItem == NO && (rightBarButtonConfiguration.image || rightBarButtonConfiguration.title))
         {
             done.title = rightBarButtonConfiguration.title;
+            done.accessibilityLabel = rightBarButtonConfiguration.accessibilityLabel;
             done.image = rightBarButtonConfiguration.image;
             done.target = target;
             done.action = rightBarButtonConfiguration.action;
@@ -437,7 +440,7 @@
         {
             done = [[IQBarButtonItem alloc] initWithImage:rightBarButtonConfiguration.image style:UIBarButtonItemStylePlain target:target action:rightBarButtonConfiguration.action];
             done.invocation = toolbar.doneBarButton.invocation;
-            done.accessibilityLabel = toolbar.doneBarButton.accessibilityLabel;
+            done.accessibilityLabel = rightBarButtonConfiguration.accessibilityLabel;
             done.enabled = toolbar.doneBarButton.enabled;
             done.tag = toolbar.doneBarButton.tag;
             toolbar.doneBarButton = done;
@@ -446,7 +449,7 @@
         {
             done = [[IQBarButtonItem alloc] initWithTitle:rightBarButtonConfiguration.title style:UIBarButtonItemStylePlain target:target action:rightBarButtonConfiguration.action];
             done.invocation = toolbar.doneBarButton.invocation;
-            done.accessibilityLabel = toolbar.doneBarButton.accessibilityLabel;
+            done.accessibilityLabel = rightBarButtonConfiguration.accessibilityLabel;
             done.enabled = toolbar.doneBarButton.enabled;
             done.tag = toolbar.doneBarButton.tag;
             toolbar.doneBarButton = done;
@@ -455,7 +458,7 @@
         {
             done = [[IQBarButtonItem alloc] initWithBarButtonSystemItem:rightBarButtonConfiguration.barButtonSystemItem target:target action:rightBarButtonConfiguration.action];
             done.invocation = toolbar.doneBarButton.invocation;
-            done.accessibilityLabel = toolbar.doneBarButton.accessibilityLabel;
+            done.accessibilityLabel = rightBarButtonConfiguration.accessibilityLabel;
             done.enabled = toolbar.doneBarButton.enabled;
             done.tag = toolbar.doneBarButton.tag;
             toolbar.doneBarButton = done;

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -293,8 +293,11 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
      Toolbar previous/next/done button text, If nothing is provided then system default 'UIBarButtonSystemItemDone' will be used.
      */
     @objc public var toolbarPreviousBarButtonItemText: String?
+    @objc public var toolbarPreviousBarButtonItemAccessibilityLabel: String?
     @objc public var toolbarNextBarButtonItemText: String?
+    @objc public var toolbarNextBarButtonItemAccessibilityLabel: String?
     @objc public var toolbarDoneBarButtonItemText: String?
+    @objc public var toolbarDoneBarButtonItemAccessibilityLabel: String?
 
     /**
     If YES, then it add the textField's placeholder text on IQToolbar. Default is YES.
@@ -1981,6 +1984,7 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
                         } else {
                             rightConfiguration = IQBarButtonItemConfiguration(barButtonSystemItem: .done, action: #selector(self.doneAction(_:)))
                         }
+                        rightConfiguration.accessibilityLabel = toolbarDoneBarButtonItemAccessibilityLabel ?? "Done"
                         
                         //	If only one object is found, then adding only Done button.
                         if (siblings.count <= 1 && previousNextDisplayMode == .default) || previousNextDisplayMode == .alwaysHide {
@@ -2000,6 +2004,7 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
                             } else {
                                 prevConfiguration = IQBarButtonItemConfiguration(image: (UIImage.keyboardPreviousImage() ?? UIImage()), action: #selector(self.previousAction(_:)))
                             }
+                            prevConfiguration.accessibilityLabel = toolbarPreviousBarButtonItemAccessibilityLabel ?? "Previous"
 
                             let nextConfiguration: IQBarButtonItemConfiguration
                             
@@ -2010,6 +2015,7 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
                             } else {
                                 nextConfiguration = IQBarButtonItemConfiguration(image: (UIImage.keyboardNextImage() ?? UIImage()), action: #selector(self.nextAction(_:)))
                             }
+                            nextConfiguration.accessibilityLabel = toolbarNextBarButtonItemAccessibilityLabel ?? "Next"
 
                             textField.addKeyboardToolbarWithTarget(target: self, titleText: (shouldShowToolbarPlaceholder ? textField.drawingToolbarPlaceholder: nil), rightBarButtonConfiguration: rightConfiguration, previousBarButtonConfiguration: prevConfiguration, nextBarButtonConfiguration: nextConfiguration)
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
@@ -54,7 +54,6 @@ open class IQToolbar: UIToolbar, UIInputViewAudioFeedback {
         get {
             if privatePreviousBarButton == nil {
                 privatePreviousBarButton = IQBarButtonItem(image: nil, style: .plain, target: nil, action: nil)
-                privatePreviousBarButton?.accessibilityLabel = "Previous"
             }
             return privatePreviousBarButton!
         }
@@ -72,7 +71,6 @@ open class IQToolbar: UIToolbar, UIInputViewAudioFeedback {
         get {
             if privateNextBarButton == nil {
                 privateNextBarButton = IQBarButtonItem(image: nil, style: .plain, target: nil, action: nil)
-                privateNextBarButton?.accessibilityLabel = "Next"
             }
             return privateNextBarButton!
         }
@@ -108,7 +106,6 @@ open class IQToolbar: UIToolbar, UIInputViewAudioFeedback {
         get {
             if privateDoneBarButton == nil {
                 privateDoneBarButton = IQBarButtonItem(title: nil, style: .done, target: nil, action: nil)
-                privateDoneBarButton?.accessibilityLabel = "Done"
             }
             return privateDoneBarButton!
         }

--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -344,6 +344,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
 
                 if prevConfig.barButtonSystemItem == nil && prev.isSystemItem == false {
                     prev.title = prevConfig.title
+                    prev.accessibilityLabel = prevConfig.accessibilityLabel
                     prev.image = prevConfig.image
                     prev.target = target
                     prev.action = prevConfig.action
@@ -358,7 +359,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
                     }
                     
                     prev.invocation = toolbar.previousBarButton.invocation
-                    prev.accessibilityLabel = toolbar.previousBarButton.accessibilityLabel
+                    prev.accessibilityLabel = prevConfig.accessibilityLabel
                     prev.isEnabled = toolbar.previousBarButton.isEnabled
                     prev.tag = toolbar.previousBarButton.tag
                     toolbar.previousBarButton = prev
@@ -378,6 +379,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
 
                 if nextConfig.barButtonSystemItem == nil && next.isSystemItem == false {
                     next.title = nextConfig.title
+                    next.accessibilityLabel = nextConfig.accessibilityLabel
                     next.image = nextConfig.image
                     next.target = target
                     next.action = nextConfig.action
@@ -392,7 +394,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
                     }
                     
                     next.invocation = toolbar.nextBarButton.invocation
-                    next.accessibilityLabel = toolbar.nextBarButton.accessibilityLabel
+                    next.accessibilityLabel = nextConfig.accessibilityLabel
                     next.isEnabled = toolbar.nextBarButton.isEnabled
                     next.tag = toolbar.nextBarButton.tag
                     toolbar.nextBarButton = next
@@ -425,6 +427,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
 
                 if rightConfig.barButtonSystemItem == nil && done.isSystemItem == false {
                     done.title = rightConfig.title
+                    done.accessibilityLabel = rightConfig.accessibilityLabel
                     done.image = rightConfig.image
                     done.target = target
                     done.action = rightConfig.action
@@ -439,7 +442,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
                     }
                     
                     done.invocation = toolbar.doneBarButton.invocation
-                    done.accessibilityLabel = toolbar.doneBarButton.accessibilityLabel
+                    done.accessibilityLabel = rightConfig.accessibilityLabel
                     done.isEnabled = toolbar.doneBarButton.isEnabled
                     done.tag = toolbar.doneBarButton.tag
                     toolbar.doneBarButton = done


### PR DESCRIPTION
# Description

We propose this simple change to be able to change the AccessibilityLabel in the buttons of the bar that's located over the keyboard. Actually we can change the title, but the AccessibilityLabel is hardcoded. 

We add 3 new properties in the shared manager to pass a custom text (if the user don't change the value, the behavior is the same of the actual version)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
