### PR TITLE
Infinite loop when searching for topmost UINavigationController fix

### DIFF
--- a/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
@@ -247,12 +247,7 @@
         if ((textField == self || textField.ignoreSwitchingByNextPrevious == NO) && [textField _IQcanBecomeFirstResponder])
         {
             [textFields addObject:textField];
-        }
-        
-        //Sometimes there are hidden or disabled views and textField inside them still recorded, so we added some more validations here (Bug ID: #458)
-        //Uncommented else (Bug ID: #625)
-        if (textField.subviews.count && [textField isUserInteractionEnabled] && ![textField isHidden] && [textField alpha]!=0.0)
-        {
+        } else if (textField.subviews.count && [textField isUserInteractionEnabled] && ![textField isHidden] && [textField alpha]!=0.0) {
             [textFields addObjectsFromArray:[textField deepResponderViews]];
         }
     }

--- a/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
+++ b/IQKeyboardManager/Categories/IQUIView+Hierarchy.m
@@ -98,7 +98,7 @@
     {
         UINavigationController *navController = matchController.navigationController;
         
-        while (navController.navigationController) {
+        while (navController.navigationController && navController != navController.navigationController) {
             navController = navController.navigationController;
         }
         


### PR DESCRIPTION
#1235 Description

When the window controller and navigation controller has the same navigation controller instance reference, the while loop searching for topmost UINavigationController freezes the app.

- [X] Bug fix (non-breaking change which fixes an issue)