### PR TITLE
IQKeyboardManagerSwift - Was required UIKit imports

### DIFF
--- a/IQKeyboardManagerSwift/Categories/IQNSArray+Sort.swift
+++ b/IQKeyboardManagerSwift/Categories/IQNSArray+Sort.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
 import UIKit
 
 /**

--- a/IQKeyboardManagerSwift/Categories/IQUIScrollView+Additions.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUIScrollView+Additions.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
 import UIKit
 
 @objc public extension UIScrollView {

--- a/IQKeyboardManagerSwift/Categories/IQUITextFieldView+Additions.swift
+++ b/IQKeyboardManagerSwift/Categories/IQUITextFieldView+Additions.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
 import UIKit
 
 /**

--- a/IQKeyboardManagerSwift/Constants/IQKeyboardManagerConstantsInternal.swift
+++ b/IQKeyboardManagerSwift/Constants/IQKeyboardManagerConstantsInternal.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
 #if swift(>=4.2)
 internal let UIKeyboardWillShowNotification  = UIResponder.keyboardWillShowNotification

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Debug.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Debug.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 // MARK: Debugging & Developer options
 public extension IQKeyboardManager {

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 internal extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+OrientationNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+OrientationNotification.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 // MARK: UIStatusBar Notification methods
 internal extension IQKeyboardManager {

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 public extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 public extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+UIKeyboardNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+UIKeyboardNotification.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 // MARK: UIKeyboard Notifications
 public extension IQKeyboardManager {

--- a/IQKeyboardManagerSwift/IQKeyboardManager+UITextFieldViewNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+UITextFieldViewNotification.swift
@@ -21,7 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
+import UIKit
 
 // MARK: UITextField/UITextView Notifications
 internal extension IQKeyboardManager {

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -21,9 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-import CoreGraphics
+// import Foundation - UIKit contains Foundation
 import UIKit
+import CoreGraphics
 import QuartzCore
 
 // MARK: IQToolbar tags

--- a/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+// import Foundation - UIKit contains Foundation
 import UIKit
 
 private class IQTextFieldViewInfoModal: NSObject {

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -21,8 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// import Foundation - UIKit contains Foundation
 import UIKit
-import Foundation
 
 open class IQBarButtonItem: UIBarButtonItem {
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
@@ -21,7 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import UIKit
 
 open class IQTitleBarButtonItem: IQBarButtonItem {


### PR DESCRIPTION
# **IQKeyboardManagerSwift** - Use of undeclared **UIKit** types

# Description

When **manually** implementing this, Xcode will throw **Red** errors about "Use of undeclared type" of UIKit types and break the code, so i fixed it with UIKit imports and commented Foundation that is redundant because UIKit contains Foundation.

Fixes # Use of undeclared type of UIKit elements

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)