### PR TITLE
update IQKeyboardReturnKeyHandler, avoid crash

### DIFF
--- a/IQKeyboardManager/IQKeyboardReturnKeyHandler.m
+++ b/IQKeyboardManager/IQKeyboardReturnKeyHandler.m
@@ -141,21 +141,27 @@
     }
 }
 
+// I want to use this function，avoid crash
 -(void)addTextFieldView:(UIView*)view
 {
     IQTextFieldViewInfoModal *modal = [[IQTextFieldViewInfoModal alloc] initWithTextFieldView:view textFieldDelegate:nil textViewDelegate:nil originalReturnKey:UIReturnKeyDefault];
-    
-    UITextField *textField = (UITextField*)view;
-
-    if ([view respondsToSelector:@selector(setReturnKeyType:)])
-    {
-        modal.originalReturnKeyType = textField.returnKeyType;
+    if ([textFieldInfoCache containsObject:modal]) {
+        return;
     }
-
-    if ([view respondsToSelector:@selector(setDelegate:)])
+    
+    if ([view isKindOfClass:[UITextField class]])
     {
+        UITextField *textField = (UITextField*)view;
+        modal.originalReturnKeyType = textField.returnKeyType;
         modal.textFieldDelegate = textField.delegate;
         [textField setDelegate:self];
+    }
+    else if ([view isKindOfClass:[UITextView class]])
+    {
+        UITextView *textView = (UITextView*)view;
+        modal.originalReturnKeyType = textView.returnKeyType;
+        modal.textViewDelegate = textView.delegate;
+        [textView setDelegate:self];
     }
 
     [textFieldInfoCache addObject:modal];


### PR DESCRIPTION
I want to use this function, avoid crash

```
-(void)addTextFieldView:(UIView*)view
{
    IQTextFieldViewInfoModal *modal = [[IQTextFieldViewInfoModal alloc] initWithTextFieldView:view textFieldDelegate:nil textViewDelegate:nil originalReturnKey:UIReturnKeyDefault];
    if ([textFieldInfoCache containsObject:modal]) {
        return;
    }
    
    UITextField *textField = (UITextField*)view;

    if ([view respondsToSelector:@selector(setReturnKeyType:)])
    {
        modal.originalReturnKeyType = textField.returnKeyType;
    }

    if ([view respondsToSelector:@selector(setDelegate:)])
    {
        modal.textFieldDelegate = textField.delegate;
        [textField setDelegate:self];
    }

    [textFieldInfoCache addObject:modal];
}
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
