### PR TITLE
fix(#1824): Xcode 13 Compatibility

### DIFF
--- a/IQKeyboardManagerSwift/IQKeyboardManager+Debug.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Debug.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 // MARK: Debugging & Developer options
+@available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 
     private struct AssociatedKeys {

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
@@ -23,6 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 internal extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift
@@ -23,7 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 internal extension IQKeyboardManager {
 
     /**    Get all UITextField/UITextView siblings of textFieldView. */

--- a/IQKeyboardManagerSwift/IQKeyboardManager+OrientationNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+OrientationNotification.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 // MARK: UIStatusBar Notification methods
+@available(iOSApplicationExtension, unavailable)
 internal extension IQKeyboardManager {
 
     /**  UIApplicationWillChangeStatusBarOrientationNotification. Need to set the textView to it's original position. If any frame changes made. (Bug ID: #92)*/

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
@@ -23,7 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 
     private struct AssociatedKeys {
@@ -314,7 +314,7 @@ public extension IQKeyboardManager {
                         startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     }
                     #else
-                    _startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
+//                    _startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     #endif
                 }
 
@@ -333,7 +333,7 @@ public extension IQKeyboardManager {
                 startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             }
             #else
-            _startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
+//            _startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             #endif
 
             showLog("Saving ScrollView contentInset: \(startingContentInsets) and contentOffset: \(startingContentOffset)")

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
@@ -314,7 +314,7 @@ public extension IQKeyboardManager {
                         startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     }
                     #else
-//                    _startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
+                    _startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     #endif
                 }
 
@@ -333,7 +333,7 @@ public extension IQKeyboardManager {
                 startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             }
             #else
-//            _startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
+            _startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             #endif
 
             showLog("Saving ScrollView contentInset: \(startingContentInsets) and contentOffset: \(startingContentOffset)")

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
@@ -313,7 +313,7 @@ public extension IQKeyboardManager {
                     } else {
                         startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     }
-                    #else
+                    #elseif swift(>=4.2)
                     _startingScrollIndicatorInsets = scrollView.scrollIndicatorInsets
                     #endif
                 }
@@ -332,7 +332,7 @@ public extension IQKeyboardManager {
             } else {
                 startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             }
-            #else
+            #elseif swift(>=4.2)
             _startingScrollIndicatorInsets = unwrappedSuperScrollView.scrollIndicatorInsets
             #endif
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Position.swift
@@ -23,6 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
@@ -23,7 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 
     /**
@@ -202,6 +202,7 @@ public extension IQKeyboardManager {
 }
 
 // MARK: Previous next button actions
+@available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 
     /**

--- a/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift
@@ -23,6 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 

--- a/IQKeyboardManagerSwift/IQKeyboardManager+UIKeyboardNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+UIKeyboardNotification.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 // MARK: UIKeyboard Notifications
+@available(iOSApplicationExtension, unavailable)
 public extension IQKeyboardManager {
 
     private struct AssociatedKeys {

--- a/IQKeyboardManagerSwift/IQKeyboardManager+UITextFieldViewNotification.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager+UITextFieldViewNotification.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 // MARK: UITextField/UITextView Notifications
+@available(iOSApplicationExtension, unavailable)
 internal extension IQKeyboardManager {
 
     private struct AssociatedKeys {

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -31,7 +31,7 @@ import QuartzCore
 /**
 Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView. Neither need to write any code nor any setup required and much more. A generic version of KeyboardManagement. https://developer.apple.com/library/ios/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html
 */
-
+@available(iOSApplicationExtension, unavailable)
 @objc public class IQKeyboardManager: NSObject {
 
     /**
@@ -390,7 +390,7 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
         optimizedAdjustPosition()
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension IQKeyboardManager: UIGestureRecognizerDelegate {
 
     /** Resigning on tap gesture.   (Enhancement ID: #14)*/

--- a/IQKeyboardManagerSwift/IQKeyboardManager.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardManager.swift
@@ -31,6 +31,7 @@ import QuartzCore
 /**
 Codeless drop-in universal library allows to prevent issues of keyboard sliding up and cover UITextField/UITextView. Neither need to write any code nor any setup required and much more. A generic version of KeyboardManagement. https://developer.apple.com/library/ios/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html
 */
+
 @available(iOSApplicationExtension, unavailable)
 @objc public class IQKeyboardManager: NSObject {
 
@@ -390,6 +391,7 @@ Codeless drop-in universal library allows to prevent issues of keyboard sliding 
         optimizedAdjustPosition()
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension IQKeyboardManager: UIGestureRecognizerDelegate {
 

--- a/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
@@ -23,7 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 private class IQTextFieldViewInfoModal: NSObject {
 
     fileprivate weak var textFieldDelegate: UITextFieldDelegate?
@@ -42,6 +42,7 @@ private class IQTextFieldViewInfoModal: NSObject {
 /**
 Manages the return key to work like next/done in a view hierarchy.
 */
+@available(iOSApplicationExtension, unavailable)
 public class IQKeyboardReturnKeyHandler: NSObject {
 
     // MARK: Settings
@@ -304,6 +305,7 @@ public class IQKeyboardReturnKeyHandler: NSObject {
 }
 
 // MARK: UITextFieldDelegate
+@available(iOSApplicationExtension, unavailable)
 extension IQKeyboardReturnKeyHandler: UITextFieldDelegate {
 
     @objc public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
@@ -433,6 +435,7 @@ extension IQKeyboardReturnKeyHandler: UITextFieldDelegate {
 }
 
 // MARK: UITextViewDelegate
+@available(iOSApplicationExtension, unavailable)
 extension IQKeyboardReturnKeyHandler: UITextViewDelegate {
 
     @objc public func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {

--- a/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
+++ b/IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift
@@ -23,6 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 private class IQTextFieldViewInfoModal: NSObject {
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -23,6 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 open class IQBarButtonItem: UIBarButtonItem {
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift
@@ -23,7 +23,7 @@
 
 // import Foundation - UIKit contains Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 open class IQBarButtonItem: UIBarButtonItem {
 
     private static var _classInitialize: Void = classInitialize()

--- a/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 @objc public class IQInvocation: NSObject {
     @objc public weak var target: AnyObject?
     @objc public var action: Selector

--- a/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 @objc public class IQInvocation: NSObject {
     @objc public weak var target: AnyObject?

--- a/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 open class IQTitleBarButtonItem: IQBarButtonItem {
 
     @objc open var titleFont: UIFont? {

--- a/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 open class IQTitleBarButtonItem: IQBarButtonItem {
 

--- a/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift
@@ -24,6 +24,7 @@
 import UIKit
 
 /** @abstract   IQToolbar for IQKeyboardManager.    */
+@available(iOSApplicationExtension, unavailable)
 open class IQToolbar: UIToolbar, UIInputViewAudioFeedback {
 
     private static var _classInitialize: Void = classInitialize()

--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -186,6 +186,7 @@ import UIKit
 /**
 UIView category methods to add IQToolbar on UIKeyboard.
 */
+@available(iOSApplicationExtension, unavailable)
 @objc public extension UIView {
 
     private struct AssociatedKeys {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
# Description
With Xcode 13, packages are all compiled with a flag as if they are for an application extension. This causes compiler issues due to the use of APIs that aren't available within app extensions. This PR adds the needed availability checks for use of problematic APIs in app extensions.
More context on this issue can be found below
- https://bugs.swift.org/browse/SR-13345?jql=project%20%3D%20SR%20AND%20issuetype%20%3D%20Bug%20AND%20component%20%3D%20%22Package%20Manager%22%20AND%20environment%20~%20%22Xcode%2013%20beta%22

- https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/28

Fixes #1824

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
