### PR TITLE
Done button added in UISearchBar's keypad tool bar

### DIFF
--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -423,6 +423,8 @@ UIView category methods to add IQToolbar on UIKeyboard.
                 textField.inputAccessoryView = toolbar
             } else if let textView = self as? UITextView {
                 textView.inputAccessoryView = toolbar
+            } else if let searchBar = self as? UISearchBar {
+                searchBar.inputAccessoryView = toolbar
             }
         }
     }


### PR DESCRIPTION
# Description

Toolbar is not working for UISearchBar,  dismiss keypad of UISearchBar is not working, so added the toolbar adding code for UISearchBar as well

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

<img width="715" alt="Screen Shot 2022-07-18 at 10 12 53 AM" src="https://user-images.githubusercontent.com/11155344/179453973-03fdcb79-1710-48d4-a55d-2bd5aadb92fd.png">

