### PR TITLE
Fix for Xcode 14 : iOS 12 crash dyld: Library not loaded: /usr/lib/sw…

### DIFF
--- a/IQKeyboardManagerSwift.podspec.json
+++ b/IQKeyboardManagerSwift.podspec.json
@@ -32,5 +32,9 @@
     "CoreGraphics",
     "QuartzCore"
   ],
+  "libraries": "swiftCoreGraphics",
+  "xcconfig": {
+      "LIBRARY_SEARCH_PATHS": "$(SDKROOT)/usr/lib/swift"
+  },
   "requires_arc": true
 }


### PR DESCRIPTION
Fix for Xcode 14 : iOS 12 crash dyld: Library not loaded: /usr/lib/swift/libswiftCoreGraphics.dylib Reason: image not found

Fixes #1912


