### PR TITLE
Add IQPlaceholderable to IQKeyboardManagerSwift Target

### DIFF
--- a/project.pbxproj
+++ b/project.pbxproj
@@ -1,0 +1,828 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		149A0FAD2AD439DB007B1E69 /* IQPlaceholderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149A0FAC2AD439DB007B1E69 /* IQPlaceholderable.swift */; };
+		4C1D987E1F752A6400F5C2EA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D987D1F752A6400F5C2EA /* UIKit.framework */; };
+		4C1D98801F752A6A00F5C2EA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D987F1F752A6A00F5C2EA /* Foundation.framework */; };
+		4C1D98821F752A7600F5C2EA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D98811F752A7600F5C2EA /* CoreGraphics.framework */; };
+		4C1D98841F752A7E00F5C2EA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D98831F752A7E00F5C2EA /* QuartzCore.framework */; };
+		4C1D98871F752ACC00F5C2EA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D98811F752A7600F5C2EA /* CoreGraphics.framework */; };
+		4C1D98881F752AD200F5C2EA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D98831F752A7E00F5C2EA /* QuartzCore.framework */; };
+		4C68CB1E1CB5779300F7286E /* IQPreviousNextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C68CB1C1CB5779300F7286E /* IQPreviousNextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C68CB1F1CB5779300F7286E /* IQPreviousNextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C68CB1D1CB5779300F7286E /* IQPreviousNextView.m */; };
+		4CC1D5951F7E84A5007595D9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D987D1F752A6400F5C2EA /* UIKit.framework */; };
+		4CC1D5961F7E84AB007595D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C1D987F1F752A6A00F5C2EA /* Foundation.framework */; };
+		4CD2C4D81C5A63A300975A7A /* IQNSArray+Sort.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4B51C5A63A300975A7A /* IQNSArray+Sort.h */; };
+		4CD2C4D91C5A63A300975A7A /* IQNSArray+Sort.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4B61C5A63A300975A7A /* IQNSArray+Sort.m */; };
+		4CD2C4DA1C5A63A300975A7A /* IQUIScrollView+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4B71C5A63A300975A7A /* IQUIScrollView+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4DB1C5A63A300975A7A /* IQUIScrollView+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4B81C5A63A300975A7A /* IQUIScrollView+Additions.m */; };
+		4CD2C4DC1C5A63A300975A7A /* IQUITextFieldView+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4B91C5A63A300975A7A /* IQUITextFieldView+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4DD1C5A63A300975A7A /* IQUITextFieldView+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4BA1C5A63A300975A7A /* IQUITextFieldView+Additions.m */; };
+		4CD2C4DE1C5A63A300975A7A /* IQUIView+Hierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4BB1C5A63A300975A7A /* IQUIView+Hierarchy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4DF1C5A63A300975A7A /* IQUIView+Hierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4BC1C5A63A300975A7A /* IQUIView+Hierarchy.m */; };
+		4CD2C4E01C5A63A300975A7A /* IQUIViewController+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4BD1C5A63A300975A7A /* IQUIViewController+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4E11C5A63A300975A7A /* IQUIViewController+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4BE1C5A63A300975A7A /* IQUIViewController+Additions.m */; };
+		4CD2C4E41C5A63A300975A7A /* IQKeyboardManagerConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4C21C5A63A300975A7A /* IQKeyboardManagerConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4E51C5A63A300975A7A /* IQKeyboardManagerConstantsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4C31C5A63A300975A7A /* IQKeyboardManagerConstantsInternal.h */; };
+		4CD2C4E61C5A63A300975A7A /* IQKeyboardManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4C41C5A63A300975A7A /* IQKeyboardManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4E71C5A63A300975A7A /* IQKeyboardManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4C51C5A63A300975A7A /* IQKeyboardManager.m */; };
+		4CD2C4E81C5A63A300975A7A /* IQKeyboardReturnKeyHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4C61C5A63A300975A7A /* IQKeyboardReturnKeyHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4E91C5A63A300975A7A /* IQKeyboardReturnKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4C71C5A63A300975A7A /* IQKeyboardReturnKeyHandler.m */; };
+		4CD2C4EA1C5A63A300975A7A /* IQTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4CA1C5A63A300975A7A /* IQTextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4EB1C5A63A300975A7A /* IQTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4CB1C5A63A300975A7A /* IQTextView.m */; };
+		4CD2C4EC1C5A63A300975A7A /* IQBarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4CD1C5A63A300975A7A /* IQBarButtonItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4ED1C5A63A300975A7A /* IQBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4CE1C5A63A300975A7A /* IQBarButtonItem.m */; };
+		4CD2C4EE1C5A63A300975A7A /* IQTitleBarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4CF1C5A63A300975A7A /* IQTitleBarButtonItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4EF1C5A63A300975A7A /* IQTitleBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4D01C5A63A300975A7A /* IQTitleBarButtonItem.m */; };
+		4CD2C4F01C5A63A300975A7A /* IQToolbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4D11C5A63A300975A7A /* IQToolbar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4F11C5A63A300975A7A /* IQToolbar.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4D21C5A63A300975A7A /* IQToolbar.m */; };
+		4CD2C4F21C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CD2C4D31C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CD2C4F31C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD2C4D41C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.m */; };
+		C088C73E2822A2E2002191E4 /* IQTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7232822A2E2002191E4 /* IQTextView.swift */; };
+		C088C73F2822A2E2002191E4 /* IQKeyboardManager+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7242822A2E2002191E4 /* IQKeyboardManager+Internal.swift */; };
+		C088C7402822A2E2002191E4 /* IQPreviousNextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7262822A2E2002191E4 /* IQPreviousNextView.swift */; };
+		C088C7412822A2E2002191E4 /* IQTitleBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7272822A2E2002191E4 /* IQTitleBarButtonItem.swift */; };
+		C088C7422822A2E2002191E4 /* IQBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7282822A2E2002191E4 /* IQBarButtonItem.swift */; };
+		C088C7432822A2E2002191E4 /* IQToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7292822A2E2002191E4 /* IQToolbar.swift */; };
+		C088C7442822A2E2002191E4 /* IQUIView+IQKeyboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C72A2822A2E2002191E4 /* IQUIView+IQKeyboardToolbar.swift */; };
+		C088C7452822A2E2002191E4 /* IQInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C72B2822A2E2002191E4 /* IQInvocation.swift */; };
+		C088C7462822A2E2002191E4 /* IQKeyboardManager+UIKeyboardNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C72C2822A2E2002191E4 /* IQKeyboardManager+UIKeyboardNotification.swift */; };
+		C088C7472822A2E2002191E4 /* IQKeyboardManagerConstantsInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C72E2822A2E2002191E4 /* IQKeyboardManagerConstantsInternal.swift */; };
+		C088C7482822A2E2002191E4 /* IQKeyboardManagerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C72F2822A2E2002191E4 /* IQKeyboardManagerConstants.swift */; };
+		C088C7492822A2E2002191E4 /* IQKeyboardManager+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7302822A2E2002191E4 /* IQKeyboardManager+Position.swift */; };
+		C088C74A2822A2E2002191E4 /* IQKeyboardReturnKeyHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7312822A2E2002191E4 /* IQKeyboardReturnKeyHandler.swift */; };
+		C088C74B2822A2E2002191E4 /* IQKeyboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7322822A2E2002191E4 /* IQKeyboardManager.swift */; };
+		C088C74C2822A2E2002191E4 /* IQKeyboardManager+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7332822A2E2002191E4 /* IQKeyboardManager+Debug.swift */; };
+		C088C74D2822A2E2002191E4 /* IQKeyboardManager+OrientationNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7342822A2E2002191E4 /* IQKeyboardManager+OrientationNotification.swift */; };
+		C088C74E2822A2E2002191E4 /* IQKeyboardManager+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7352822A2E2002191E4 /* IQKeyboardManager+Toolbar.swift */; };
+		C088C74F2822A2E2002191E4 /* IQKeyboardManagerSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = C088C7362822A2E2002191E4 /* IQKeyboardManagerSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C088C7502822A2E2002191E4 /* IQUIScrollView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7382822A2E2002191E4 /* IQUIScrollView+Additions.swift */; };
+		C088C7512822A2E2002191E4 /* IQUIViewController+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C7392822A2E2002191E4 /* IQUIViewController+Additions.swift */; };
+		C088C7522822A2E2002191E4 /* IQUITextFieldView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C73A2822A2E2002191E4 /* IQUITextFieldView+Additions.swift */; };
+		C088C7532822A2E2002191E4 /* IQUIView+Hierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C73B2822A2E2002191E4 /* IQUIView+Hierarchy.swift */; };
+		C088C7542822A2E2002191E4 /* IQNSArray+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C73C2822A2E2002191E4 /* IQNSArray+Sort.swift */; };
+		C088C7552822A2E2002191E4 /* IQKeyboardManager+UITextFieldViewNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088C73D2822A2E2002191E4 /* IQKeyboardManager+UITextFieldViewNotification.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		149A0FAC2AD439DB007B1E69 /* IQPlaceholderable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQPlaceholderable.swift; sourceTree = "<group>"; };
+		4C1D987D1F752A6400F5C2EA /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		4C1D987F1F752A6A00F5C2EA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		4C1D98811F752A7600F5C2EA /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		4C1D98831F752A7E00F5C2EA /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		4C68CB1C1CB5779300F7286E /* IQPreviousNextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQPreviousNextView.h; sourceTree = "<group>"; };
+		4C68CB1D1CB5779300F7286E /* IQPreviousNextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQPreviousNextView.m; sourceTree = "<group>"; };
+		4CD2C4A61C5A615600975A7A /* IQKeyboardManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IQKeyboardManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CD2C4B51C5A63A300975A7A /* IQNSArray+Sort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQNSArray+Sort.h"; sourceTree = "<group>"; };
+		4CD2C4B61C5A63A300975A7A /* IQNSArray+Sort.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQNSArray+Sort.m"; sourceTree = "<group>"; };
+		4CD2C4B71C5A63A300975A7A /* IQUIScrollView+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQUIScrollView+Additions.h"; sourceTree = "<group>"; };
+		4CD2C4B81C5A63A300975A7A /* IQUIScrollView+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQUIScrollView+Additions.m"; sourceTree = "<group>"; };
+		4CD2C4B91C5A63A300975A7A /* IQUITextFieldView+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQUITextFieldView+Additions.h"; sourceTree = "<group>"; };
+		4CD2C4BA1C5A63A300975A7A /* IQUITextFieldView+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQUITextFieldView+Additions.m"; sourceTree = "<group>"; };
+		4CD2C4BB1C5A63A300975A7A /* IQUIView+Hierarchy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQUIView+Hierarchy.h"; sourceTree = "<group>"; };
+		4CD2C4BC1C5A63A300975A7A /* IQUIView+Hierarchy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQUIView+Hierarchy.m"; sourceTree = "<group>"; };
+		4CD2C4BD1C5A63A300975A7A /* IQUIViewController+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQUIViewController+Additions.h"; sourceTree = "<group>"; };
+		4CD2C4BE1C5A63A300975A7A /* IQUIViewController+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQUIViewController+Additions.m"; sourceTree = "<group>"; };
+		4CD2C4C21C5A63A300975A7A /* IQKeyboardManagerConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardManagerConstants.h; sourceTree = "<group>"; };
+		4CD2C4C31C5A63A300975A7A /* IQKeyboardManagerConstantsInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardManagerConstantsInternal.h; sourceTree = "<group>"; };
+		4CD2C4C41C5A63A300975A7A /* IQKeyboardManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardManager.h; sourceTree = "<group>"; };
+		4CD2C4C51C5A63A300975A7A /* IQKeyboardManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQKeyboardManager.m; sourceTree = "<group>"; };
+		4CD2C4C61C5A63A300975A7A /* IQKeyboardReturnKeyHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardReturnKeyHandler.h; sourceTree = "<group>"; };
+		4CD2C4C71C5A63A300975A7A /* IQKeyboardReturnKeyHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQKeyboardReturnKeyHandler.m; sourceTree = "<group>"; };
+		4CD2C4CA1C5A63A300975A7A /* IQTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQTextView.h; sourceTree = "<group>"; };
+		4CD2C4CB1C5A63A300975A7A /* IQTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQTextView.m; sourceTree = "<group>"; };
+		4CD2C4CD1C5A63A300975A7A /* IQBarButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQBarButtonItem.h; sourceTree = "<group>"; };
+		4CD2C4CE1C5A63A300975A7A /* IQBarButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQBarButtonItem.m; sourceTree = "<group>"; };
+		4CD2C4CF1C5A63A300975A7A /* IQTitleBarButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQTitleBarButtonItem.h; sourceTree = "<group>"; };
+		4CD2C4D01C5A63A300975A7A /* IQTitleBarButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQTitleBarButtonItem.m; sourceTree = "<group>"; };
+		4CD2C4D11C5A63A300975A7A /* IQToolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQToolbar.h; sourceTree = "<group>"; };
+		4CD2C4D21C5A63A300975A7A /* IQToolbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IQToolbar.m; sourceTree = "<group>"; };
+		4CD2C4D31C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IQUIView+IQKeyboardToolbar.h"; sourceTree = "<group>"; };
+		4CD2C4D41C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IQUIView+IQKeyboardToolbar.m"; sourceTree = "<group>"; };
+		4CD2C4F71C5A640900975A7A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Demo/Objective_C_Demo/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
+		4CD5970C1D1C5EBE00AB28D3 /* IQKeyboardManagerSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IQKeyboardManagerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CD597401D1C602500AB28D3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Demo/Swift_Demo/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
+		C088C7232822A2E2002191E4 /* IQTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQTextView.swift; sourceTree = "<group>"; };
+		C088C7242822A2E2002191E4 /* IQKeyboardManager+Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+Internal.swift"; sourceTree = "<group>"; };
+		C088C7262822A2E2002191E4 /* IQPreviousNextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQPreviousNextView.swift; sourceTree = "<group>"; };
+		C088C7272822A2E2002191E4 /* IQTitleBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQTitleBarButtonItem.swift; sourceTree = "<group>"; };
+		C088C7282822A2E2002191E4 /* IQBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQBarButtonItem.swift; sourceTree = "<group>"; };
+		C088C7292822A2E2002191E4 /* IQToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQToolbar.swift; sourceTree = "<group>"; };
+		C088C72A2822A2E2002191E4 /* IQUIView+IQKeyboardToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUIView+IQKeyboardToolbar.swift"; sourceTree = "<group>"; };
+		C088C72B2822A2E2002191E4 /* IQInvocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQInvocation.swift; sourceTree = "<group>"; };
+		C088C72C2822A2E2002191E4 /* IQKeyboardManager+UIKeyboardNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+UIKeyboardNotification.swift"; sourceTree = "<group>"; };
+		C088C72E2822A2E2002191E4 /* IQKeyboardManagerConstantsInternal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQKeyboardManagerConstantsInternal.swift; sourceTree = "<group>"; };
+		C088C72F2822A2E2002191E4 /* IQKeyboardManagerConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQKeyboardManagerConstants.swift; sourceTree = "<group>"; };
+		C088C7302822A2E2002191E4 /* IQKeyboardManager+Position.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+Position.swift"; sourceTree = "<group>"; };
+		C088C7312822A2E2002191E4 /* IQKeyboardReturnKeyHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQKeyboardReturnKeyHandler.swift; sourceTree = "<group>"; };
+		C088C7322822A2E2002191E4 /* IQKeyboardManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQKeyboardManager.swift; sourceTree = "<group>"; };
+		C088C7332822A2E2002191E4 /* IQKeyboardManager+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+Debug.swift"; sourceTree = "<group>"; };
+		C088C7342822A2E2002191E4 /* IQKeyboardManager+OrientationNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+OrientationNotification.swift"; sourceTree = "<group>"; };
+		C088C7352822A2E2002191E4 /* IQKeyboardManager+Toolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+Toolbar.swift"; sourceTree = "<group>"; };
+		C088C7362822A2E2002191E4 /* IQKeyboardManagerSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IQKeyboardManagerSwift.h; sourceTree = "<group>"; };
+		C088C7382822A2E2002191E4 /* IQUIScrollView+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUIScrollView+Additions.swift"; sourceTree = "<group>"; };
+		C088C7392822A2E2002191E4 /* IQUIViewController+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUIViewController+Additions.swift"; sourceTree = "<group>"; };
+		C088C73A2822A2E2002191E4 /* IQUITextFieldView+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUITextFieldView+Additions.swift"; sourceTree = "<group>"; };
+		C088C73B2822A2E2002191E4 /* IQUIView+Hierarchy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQUIView+Hierarchy.swift"; sourceTree = "<group>"; };
+		C088C73C2822A2E2002191E4 /* IQNSArray+Sort.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQNSArray+Sort.swift"; sourceTree = "<group>"; };
+		C088C73D2822A2E2002191E4 /* IQKeyboardManager+UITextFieldViewNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+UITextFieldViewNotification.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4CD2C4A21C5A615600975A7A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C1D98841F752A7E00F5C2EA /* QuartzCore.framework in Frameworks */,
+				4C1D98821F752A7600F5C2EA /* CoreGraphics.framework in Frameworks */,
+				4C1D98801F752A6A00F5C2EA /* Foundation.framework in Frameworks */,
+				4C1D987E1F752A6400F5C2EA /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CD597081D1C5EBE00AB28D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CC1D5961F7E84AB007595D9 /* Foundation.framework in Frameworks */,
+				4CC1D5951F7E84A5007595D9 /* UIKit.framework in Frameworks */,
+				4C1D98881F752AD200F5C2EA /* QuartzCore.framework in Frameworks */,
+				4C1D98871F752ACC00F5C2EA /* CoreGraphics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4C1D987C1F752A6400F5C2EA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4C1D98831F752A7E00F5C2EA /* QuartzCore.framework */,
+				4C1D98811F752A7600F5C2EA /* CoreGraphics.framework */,
+				4C1D987F1F752A6A00F5C2EA /* Foundation.framework */,
+				4C1D987D1F752A6400F5C2EA /* UIKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4CD2C49C1C5A615600975A7A = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4B31C5A63A300975A7A /* IQKeyboardManager */,
+				C088C7212822A2E2002191E4 /* IQKeyboardManagerSwift */,
+				4CD2C4F61C5A63DF00975A7A /* Supporting Files */,
+				4CD2C4A71C5A615600975A7A /* Products */,
+				4C1D987C1F752A6400F5C2EA /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		4CD2C4A71C5A615600975A7A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4A61C5A615600975A7A /* IQKeyboardManager.framework */,
+				4CD5970C1D1C5EBE00AB28D3 /* IQKeyboardManagerSwift.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4CD2C4B31C5A63A300975A7A /* IQKeyboardManager */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4B41C5A63A300975A7A /* Categories */,
+				4CD2C4C11C5A63A300975A7A /* Constants */,
+				4CD2C4C41C5A63A300975A7A /* IQKeyboardManager.h */,
+				4CD2C4C51C5A63A300975A7A /* IQKeyboardManager.m */,
+				4CD2C4C61C5A63A300975A7A /* IQKeyboardReturnKeyHandler.h */,
+				4CD2C4C71C5A63A300975A7A /* IQKeyboardReturnKeyHandler.m */,
+				4CD2C4C91C5A63A300975A7A /* IQTextView */,
+				4CD2C4CC1C5A63A300975A7A /* IQToolbar */,
+			);
+			path = IQKeyboardManager;
+			sourceTree = "<group>";
+		};
+		4CD2C4B41C5A63A300975A7A /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4B51C5A63A300975A7A /* IQNSArray+Sort.h */,
+				4CD2C4B61C5A63A300975A7A /* IQNSArray+Sort.m */,
+				4CD2C4B71C5A63A300975A7A /* IQUIScrollView+Additions.h */,
+				4CD2C4B81C5A63A300975A7A /* IQUIScrollView+Additions.m */,
+				4CD2C4B91C5A63A300975A7A /* IQUITextFieldView+Additions.h */,
+				4CD2C4BA1C5A63A300975A7A /* IQUITextFieldView+Additions.m */,
+				4CD2C4BB1C5A63A300975A7A /* IQUIView+Hierarchy.h */,
+				4CD2C4BC1C5A63A300975A7A /* IQUIView+Hierarchy.m */,
+				4CD2C4BD1C5A63A300975A7A /* IQUIViewController+Additions.h */,
+				4CD2C4BE1C5A63A300975A7A /* IQUIViewController+Additions.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		4CD2C4C11C5A63A300975A7A /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4C21C5A63A300975A7A /* IQKeyboardManagerConstants.h */,
+				4CD2C4C31C5A63A300975A7A /* IQKeyboardManagerConstantsInternal.h */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
+		4CD2C4C91C5A63A300975A7A /* IQTextView */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4CA1C5A63A300975A7A /* IQTextView.h */,
+				4CD2C4CB1C5A63A300975A7A /* IQTextView.m */,
+			);
+			path = IQTextView;
+			sourceTree = "<group>";
+		};
+		4CD2C4CC1C5A63A300975A7A /* IQToolbar */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4CD1C5A63A300975A7A /* IQBarButtonItem.h */,
+				4CD2C4CE1C5A63A300975A7A /* IQBarButtonItem.m */,
+				4C68CB1C1CB5779300F7286E /* IQPreviousNextView.h */,
+				4C68CB1D1CB5779300F7286E /* IQPreviousNextView.m */,
+				4CD2C4CF1C5A63A300975A7A /* IQTitleBarButtonItem.h */,
+				4CD2C4D01C5A63A300975A7A /* IQTitleBarButtonItem.m */,
+				4CD2C4D11C5A63A300975A7A /* IQToolbar.h */,
+				4CD2C4D21C5A63A300975A7A /* IQToolbar.m */,
+				4CD2C4D31C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.h */,
+				4CD2C4D41C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.m */,
+			);
+			path = IQToolbar;
+			sourceTree = "<group>";
+		};
+		4CD2C4F61C5A63DF00975A7A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2C4F71C5A640900975A7A /* Info.plist */,
+				4CD597401D1C602500AB28D3 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			path = IQKeyboardManager;
+			sourceTree = "<group>";
+		};
+		C088C7212822A2E2002191E4 /* IQKeyboardManagerSwift */ = {
+			isa = PBXGroup;
+			children = (
+				C088C7222822A2E2002191E4 /* IQTextView */,
+				C088C7242822A2E2002191E4 /* IQKeyboardManager+Internal.swift */,
+				C088C7252822A2E2002191E4 /* IQToolbar */,
+				C088C72C2822A2E2002191E4 /* IQKeyboardManager+UIKeyboardNotification.swift */,
+				C088C72D2822A2E2002191E4 /* Constants */,
+				C088C7302822A2E2002191E4 /* IQKeyboardManager+Position.swift */,
+				C088C7312822A2E2002191E4 /* IQKeyboardReturnKeyHandler.swift */,
+				C088C7322822A2E2002191E4 /* IQKeyboardManager.swift */,
+				C088C7332822A2E2002191E4 /* IQKeyboardManager+Debug.swift */,
+				C088C7342822A2E2002191E4 /* IQKeyboardManager+OrientationNotification.swift */,
+				C088C7352822A2E2002191E4 /* IQKeyboardManager+Toolbar.swift */,
+				C088C7362822A2E2002191E4 /* IQKeyboardManagerSwift.h */,
+				C088C7372822A2E2002191E4 /* Categories */,
+				C088C73D2822A2E2002191E4 /* IQKeyboardManager+UITextFieldViewNotification.swift */,
+			);
+			path = IQKeyboardManagerSwift;
+			sourceTree = "<group>";
+		};
+		C088C7222822A2E2002191E4 /* IQTextView */ = {
+			isa = PBXGroup;
+			children = (
+				149A0FAC2AD439DB007B1E69 /* IQPlaceholderable.swift */,
+				C088C7232822A2E2002191E4 /* IQTextView.swift */,
+			);
+			path = IQTextView;
+			sourceTree = "<group>";
+		};
+		C088C7252822A2E2002191E4 /* IQToolbar */ = {
+			isa = PBXGroup;
+			children = (
+				C088C7262822A2E2002191E4 /* IQPreviousNextView.swift */,
+				C088C7272822A2E2002191E4 /* IQTitleBarButtonItem.swift */,
+				C088C7282822A2E2002191E4 /* IQBarButtonItem.swift */,
+				C088C7292822A2E2002191E4 /* IQToolbar.swift */,
+				C088C72A2822A2E2002191E4 /* IQUIView+IQKeyboardToolbar.swift */,
+				C088C72B2822A2E2002191E4 /* IQInvocation.swift */,
+			);
+			path = IQToolbar;
+			sourceTree = "<group>";
+		};
+		C088C72D2822A2E2002191E4 /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				C088C72E2822A2E2002191E4 /* IQKeyboardManagerConstantsInternal.swift */,
+				C088C72F2822A2E2002191E4 /* IQKeyboardManagerConstants.swift */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
+		C088C7372822A2E2002191E4 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				C088C7382822A2E2002191E4 /* IQUIScrollView+Additions.swift */,
+				C088C7392822A2E2002191E4 /* IQUIViewController+Additions.swift */,
+				C088C73A2822A2E2002191E4 /* IQUITextFieldView+Additions.swift */,
+				C088C73B2822A2E2002191E4 /* IQUIView+Hierarchy.swift */,
+				C088C73C2822A2E2002191E4 /* IQNSArray+Sort.swift */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4CD2C4A31C5A615600975A7A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CD2C4E61C5A63A300975A7A /* IQKeyboardManager.h in Headers */,
+				4CD2C4E81C5A63A300975A7A /* IQKeyboardReturnKeyHandler.h in Headers */,
+				4CD2C4DC1C5A63A300975A7A /* IQUITextFieldView+Additions.h in Headers */,
+				4CD2C4E01C5A63A300975A7A /* IQUIViewController+Additions.h in Headers */,
+				4CD2C4F21C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.h in Headers */,
+				4CD2C4EC1C5A63A300975A7A /* IQBarButtonItem.h in Headers */,
+				4CD2C4EA1C5A63A300975A7A /* IQTextView.h in Headers */,
+				4CD2C4DA1C5A63A300975A7A /* IQUIScrollView+Additions.h in Headers */,
+				4CD2C4E41C5A63A300975A7A /* IQKeyboardManagerConstants.h in Headers */,
+				4CD2C4F01C5A63A300975A7A /* IQToolbar.h in Headers */,
+				4CD2C4DE1C5A63A300975A7A /* IQUIView+Hierarchy.h in Headers */,
+				4C68CB1E1CB5779300F7286E /* IQPreviousNextView.h in Headers */,
+				4CD2C4EE1C5A63A300975A7A /* IQTitleBarButtonItem.h in Headers */,
+				4CD2C4E51C5A63A300975A7A /* IQKeyboardManagerConstantsInternal.h in Headers */,
+				4CD2C4D81C5A63A300975A7A /* IQNSArray+Sort.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CD597091D1C5EBE00AB28D3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C088C74F2822A2E2002191E4 /* IQKeyboardManagerSwift.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4CD2C4A51C5A615600975A7A /* IQKeyboardManager */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4CD2C4AE1C5A615600975A7A /* Build configuration list for PBXNativeTarget "IQKeyboardManager" */;
+			buildPhases = (
+				4CD2C4A11C5A615600975A7A /* Sources */,
+				4CD2C4A21C5A615600975A7A /* Frameworks */,
+				4CD2C4A31C5A615600975A7A /* Headers */,
+				4CD2C4A41C5A615600975A7A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IQKeyboardManager;
+			productName = IQKeyboardManager;
+			productReference = 4CD2C4A61C5A615600975A7A /* IQKeyboardManager.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4CD5970B1D1C5EBE00AB28D3 /* IQKeyboardManagerSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4CD597111D1C5EBE00AB28D3 /* Build configuration list for PBXNativeTarget "IQKeyboardManagerSwift" */;
+			buildPhases = (
+				4CD597091D1C5EBE00AB28D3 /* Headers */,
+				4CD597071D1C5EBE00AB28D3 /* Sources */,
+				4CD597081D1C5EBE00AB28D3 /* Frameworks */,
+				4CD5970A1D1C5EBE00AB28D3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IQKeyboardManagerSwift;
+			productName = IQKeyboardManagerSwift;
+			productReference = 4CD5970C1D1C5EBE00AB28D3 /* IQKeyboardManagerSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4CD2C49D1C5A615600975A7A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1320;
+				ORGANIZATIONNAME = IQKeyboardManager;
+				TargetAttributes = {
+					4CD2C4A51C5A615600975A7A = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					4CD5970B1D1C5EBE00AB28D3 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 4CD2C4A01C5A615600975A7A /* Build configuration list for PBXProject "IQKeyboardManager" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 4CD2C49C1C5A615600975A7A;
+			productRefGroup = 4CD2C4A71C5A615600975A7A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4CD2C4A51C5A615600975A7A /* IQKeyboardManager */,
+				4CD5970B1D1C5EBE00AB28D3 /* IQKeyboardManagerSwift */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4CD2C4A41C5A615600975A7A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CD5970A1D1C5EBE00AB28D3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4CD2C4A11C5A615600975A7A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CD2C4DF1C5A63A300975A7A /* IQUIView+Hierarchy.m in Sources */,
+				4CD2C4E91C5A63A300975A7A /* IQKeyboardReturnKeyHandler.m in Sources */,
+				4CD2C4E71C5A63A300975A7A /* IQKeyboardManager.m in Sources */,
+				4CD2C4E11C5A63A300975A7A /* IQUIViewController+Additions.m in Sources */,
+				4CD2C4DD1C5A63A300975A7A /* IQUITextFieldView+Additions.m in Sources */,
+				4CD2C4ED1C5A63A300975A7A /* IQBarButtonItem.m in Sources */,
+				4CD2C4D91C5A63A300975A7A /* IQNSArray+Sort.m in Sources */,
+				4CD2C4EB1C5A63A300975A7A /* IQTextView.m in Sources */,
+				4CD2C4EF1C5A63A300975A7A /* IQTitleBarButtonItem.m in Sources */,
+				4CD2C4DB1C5A63A300975A7A /* IQUIScrollView+Additions.m in Sources */,
+				4CD2C4F31C5A63A300975A7A /* IQUIView+IQKeyboardToolbar.m in Sources */,
+				4C68CB1F1CB5779300F7286E /* IQPreviousNextView.m in Sources */,
+				4CD2C4F11C5A63A300975A7A /* IQToolbar.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CD597071D1C5EBE00AB28D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C088C7552822A2E2002191E4 /* IQKeyboardManager+UITextFieldViewNotification.swift in Sources */,
+				C088C74C2822A2E2002191E4 /* IQKeyboardManager+Debug.swift in Sources */,
+				C088C74A2822A2E2002191E4 /* IQKeyboardReturnKeyHandler.swift in Sources */,
+				149A0FAD2AD439DB007B1E69 /* IQPlaceholderable.swift in Sources */,
+				C088C7442822A2E2002191E4 /* IQUIView+IQKeyboardToolbar.swift in Sources */,
+				C088C7482822A2E2002191E4 /* IQKeyboardManagerConstants.swift in Sources */,
+				C088C7532822A2E2002191E4 /* IQUIView+Hierarchy.swift in Sources */,
+				C088C7492822A2E2002191E4 /* IQKeyboardManager+Position.swift in Sources */,
+				C088C7452822A2E2002191E4 /* IQInvocation.swift in Sources */,
+				C088C73F2822A2E2002191E4 /* IQKeyboardManager+Internal.swift in Sources */,
+				C088C74B2822A2E2002191E4 /* IQKeyboardManager.swift in Sources */,
+				C088C7412822A2E2002191E4 /* IQTitleBarButtonItem.swift in Sources */,
+				C088C74E2822A2E2002191E4 /* IQKeyboardManager+Toolbar.swift in Sources */,
+				C088C7522822A2E2002191E4 /* IQUITextFieldView+Additions.swift in Sources */,
+				C088C73E2822A2E2002191E4 /* IQTextView.swift in Sources */,
+				C088C7472822A2E2002191E4 /* IQKeyboardManagerConstantsInternal.swift in Sources */,
+				C088C7512822A2E2002191E4 /* IQUIViewController+Additions.swift in Sources */,
+				C088C7462822A2E2002191E4 /* IQKeyboardManager+UIKeyboardNotification.swift in Sources */,
+				C088C7542822A2E2002191E4 /* IQNSArray+Sort.swift in Sources */,
+				C088C7402822A2E2002191E4 /* IQPreviousNextView.swift in Sources */,
+				C088C7422822A2E2002191E4 /* IQBarButtonItem.swift in Sources */,
+				C088C74D2822A2E2002191E4 /* IQKeyboardManager+OrientationNotification.swift in Sources */,
+				C088C7432822A2E2002191E4 /* IQToolbar.swift in Sources */,
+				C088C7502822A2E2002191E4 /* IQUIScrollView+Additions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4CD2C4AC1C5A615600975A7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_STRICT_SELECTOR_MATCH = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_LABEL = YES;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 6.5;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4CD2C4AD1C5A615600975A7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_STRICT_SELECTOR_MATCH = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_LABEL = YES;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 6.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4CD2C4AF1C5A615600975A7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 6.5.7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				INFOPLIST_FILE = "$(SRCROOT)/Demo/Objective_C_Demo/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.iftekhar.IQKeyboardManager;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4CD2C4B01C5A615600975A7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 6.5.7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				INFOPLIST_FILE = "$(SRCROOT)/Demo/Objective_C_Demo/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.iftekhar.IQKeyboardManager;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		4CD597121D1C5EBE00AB28D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_WARN_FLOAT_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 6.5.7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNUSED_PARAMETER = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Demo/Swift_Demo/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Iftekhar.IQKeyboardManagerSwift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		4CD597131D1C5EBE00AB28D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CLANG_WARN_FLOAT_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 6.5.7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNUSED_PARAMETER = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Demo/Swift_Demo/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Iftekhar.IQKeyboardManagerSwift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4CD2C4A01C5A615600975A7A /* Build configuration list for PBXProject "IQKeyboardManager" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CD2C4AC1C5A615600975A7A /* Debug */,
+				4CD2C4AD1C5A615600975A7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4CD2C4AE1C5A615600975A7A /* Build configuration list for PBXNativeTarget "IQKeyboardManager" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CD2C4AF1C5A615600975A7A /* Debug */,
+				4CD2C4B01C5A615600975A7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4CD597111D1C5EBE00AB28D3 /* Build configuration list for PBXNativeTarget "IQKeyboardManagerSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CD597121D1C5EBE00AB28D3 /* Debug */,
+				4CD597131D1C5EBE00AB28D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4CD2C49D1C5A615600975A7A /* Project object */;
+}


### PR DESCRIPTION
Fix the issue where target IQKeyboardManagerSwift was not able to compile due to missing 'IQPlaceholderable'

Fixed the issue by adding the needed file to target

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)