### PR TITLE
Use `UIApplication` and `view.windowScene.screen` instead of `UIScreen.main` on iOS 13.0 and later

### DIFF
--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -146,8 +146,7 @@ UIView category methods to add IQToolbar on UIKeyboard.
             var width: CGFloat = 0
             
             if #available(iOS 13.0, *) {
-                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                width = windowScene?.screen.bounds.width ?? .zero
+                width = window?.windowScene?.screen.bounds.width ?? .zero
             } else {
                 width = UIScreen.main.bounds.width
             }

--- a/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
+++ b/IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift
@@ -143,7 +143,16 @@ UIView category methods to add IQToolbar on UIKeyboard.
             return unwrappedToolbar
         } else {
 
-            let frame = CGRect(origin: .zero, size: .init(width: UIScreen.main.bounds.width, height: 44))
+            var width: CGFloat = 0
+            
+            if #available(iOS 13.0, *) {
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                width = windowScene?.screen.bounds.width ?? .zero
+            } else {
+                width = UIScreen.main.bounds.width
+            }
+            
+            let frame = CGRect(origin: .zero, size: .init(width: width, height: 44))
             let newToolbar = IQToolbar(frame: frame)
 
             objc_setAssociatedObject(self, &AssociatedKeys.keyboardToolbar, newToolbar, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
# Description

`UIScree.main` will be deprecated in a future version of iOS.
I used Use `UIApplication` and `view.windowScene.screen` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `UIApplication` and `view.windowScene.screen` is the others way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.
Fixes #1988

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

