### PR TITLE
fix: privacy manifest collected data type record updated

### DIFF
--- a/IQKeyboardManager/PrivacyInfo.xcprivacy
+++ b/IQKeyboardManager/PrivacyInfo.xcprivacy
@@ -3,7 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/IQKeyboardManagerSwift/PrivacyInfo.xcprivacy
+++ b/IQKeyboardManagerSwift/PrivacyInfo.xcprivacy
@@ -3,7 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
# Description

 IQKeyboardManager privacy data missing in the application privacy report.

[Reference](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests)


Fixes #2012


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
