### PR TITLE
fix: privacy manifest file specified by Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     targets: [
         .target(
             name: "IQKeyboardManagerSwift",
-            path: "IQKeyboardManagerSwift"
+            path: "IQKeyboardManagerSwift",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     ]
 )


### PR DESCRIPTION
# Description

Currently privacy manifest file doesn't handle by Swift Package Manger. To add the SDK privacy manifest into app bundle need to add as resource into the target.

**To Reproduce**
Steps to reproduce the behavior:
1. Add the dependency by Swift Package Manager
2. Archive the app.
3. Generate the privacy report and save to disk.
4. Check the report, didn't find the IQKeyboardManager privacy report.

**Expected behavior**
There should be seperate segment for IQKeyboardManager in the privacy report

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
