### PR TITLE
Fixed TextView cursor issue

### DIFF
--- a/IQKeyboardManager/IQTextView/IQTextView.m
+++ b/IQKeyboardManager/IQTextView/IQTextView.m
@@ -210,4 +210,20 @@ NS_EXTENSION_UNAVAILABLE_IOS("Unavailable in extension")
     return newSize;
 }
 
+- (CGRect)caretRectForPosition:(UITextPosition *)position {
+    
+    CGRect originalRect = [super caretRectForPosition:position];
+        // When placeholder is visible and text alignment is centered
+    if (_placeholderLabel.alpha == 1 && self.textAlignment == NSTextAlignmentCenter) {
+        // Calculate the width of the placeholder text
+        CGSize textSize = [_placeholderLabel.text sizeWithAttributes:@{NSFontAttributeName:_placeholderLabel.font}];
+        // Calculate the starting x position of the centered placeholder text
+        CGFloat centeredTextX = (self.bounds.size.width - textSize.width) / 2;
+        // Update the caret position to match the starting x position of the centered text
+        originalRect.origin.x = centeredTextX;
+    }
+    
+    return originalRect;
+}
+
 @end

--- a/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
+++ b/IQKeyboardManagerSwift/IQTextView/IQTextView.swift
@@ -192,4 +192,21 @@ import UIKit
 
         return newSize
     }
+    
+    @objc override open func caretRect(for position: UITextPosition) -> CGRect {
+        var originalRect = super.caretRect(for: position)
+
+        // When placeholder is visible and text alignment is centered
+        if placeholderLabel.alpha == 1 && self.textAlignment == .center {
+            // Calculate the width of the placeholder text
+            let textSize = placeholderLabel.text?.size(withAttributes: [.font: placeholderLabel.font ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)]) ?? .zero
+            // Calculate the starting x position of the centered placeholder text
+            let centeredTextX = (self.bounds.size.width - textSize.width) / 2
+            // Update the caret position to match the starting x position of the centered text
+            originalRect.origin.x = centeredTextX
+        }
+
+        return originalRect
+    } 
+    
 }


### PR DESCRIPTION
# Description
Fixed Cursor Position in Centered aligned TextView is wrong #196 in Objective-C and Swift.
Fixes # (issue)
#1967 
## Type of change
Cosmetic Change
