### PR TITLE
Remove unnecessary value from privacy manifest file

### DIFF
--- a/IQKeyboardManager/PrivacyInfo.xcprivacy
+++ b/IQKeyboardManager/PrivacyInfo.xcprivacy
@@ -2,21 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/IQKeyboardManagerSwift/PrivacyInfo.xcprivacy
+++ b/IQKeyboardManagerSwift/PrivacyInfo.xcprivacy
@@ -2,21 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
# Description

- As commented by [this](https://github.com/hackiftekhar/IQKeyboardManager/pull/2013#issuecomment-1954555108), there are unnecessary empty values in the PrivacyInfo.xcprivacy file.
  - Unlike the other libraries, only IQKeyboardManager exposes an empty Additional Data item in PrivacyInfoReport, which I think is unnecessary
  ![Screenshot 2024-03-29 at 11 13 22 AM](https://github.com/hackiftekhar/IQKeyboardManager/assets/51021614/7f7972c0-a817-4e8c-bce9-735e4fd25b70)

- Added a default value

Fixes #2013